### PR TITLE
Andrew medlin/fix inventory cleanup

### DIFF
--- a/seismic/inventory/engd2stxml.py
+++ b/seismic/inventory/engd2stxml.py
@@ -17,20 +17,22 @@ Cleanup steps applied:
 * Merge overlapping channel dates for given NET.STAT.CHAN to a single epoch, since seiscomp3 rejects such overlapping dates.
 """
 
+# pylint: disable=too-many-locals, invalid-name
+
 from __future__ import division
 from __future__ import print_function
 
 import os
 import sys
 import argparse
+from collections import namedtuple, defaultdict
+import time
+import datetime
 
 import numpy as np
 import scipy as sp
-import datetime
 import pandas as pd
-from collections import namedtuple, defaultdict
 import requests as req
-import time
 
 import obspy
 from obspy import read_inventory
@@ -61,7 +63,7 @@ print("Using obspy version {}".format(obspy.__version__))
 try:
     import tqdm
     show_progress = True
-except:
+except ImportError:
     show_progress = False
     print("Run 'pip install tqdm' to see progress bar.")
 
@@ -220,7 +222,7 @@ def read_isc(fname):
                     df_all = pkl.load(f)
                     reportStationCount(df_all)
                     return df_all
-            except:
+            except Exception:
                 reportUnpickleFail(pkl_name)
 
     print("Parsing " + fname)
@@ -560,7 +562,6 @@ def mergeOverlappingChannelEpochs(df):
         df.drop(removal_index, inplace=True)
 
 
-
 def cleanupDatabase(df):
     """
     Main cleanup function encompassing the sequential data cleanup steps.
@@ -571,6 +572,7 @@ def cleanupDatabase(df):
     :rtype: pandas.DataFrame conforming to table_format.TABLE_SCHEMA
     """
     # Returns cleaned up df.
+
     print("Removing stations with illegal station code...")
     num_before = len(df)
     removeIllegalStationNames(df)
@@ -686,7 +688,7 @@ def exportNetworkPlots(df, plot_folder):
         saveNetworkLocalPlots(df, plot_folder, pbar.update)
         if show_progress:
             pbar.close()
-    except:
+    except Exception:
         if show_progress:
             pbar.close()
         raise
@@ -898,7 +900,7 @@ def main(iris_xml_file):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("-i", "--iris", help="Path to IRIS station xml database file to use to exclude station codes from STN sources.")
+    parser.add_argument("-i", "--iris", help="Path to IRIS station xml database file.")
     args = parser.parse_args()
     if args.iris is None:
         print("Running test mode")

--- a/seismic/inventory/fdsnxml_convert.py
+++ b/seismic/inventory/fdsnxml_convert.py
@@ -9,23 +9,17 @@ Can be used as a standalone tool as well:
 import os
 import sys
 import subprocess
+import tempfile
+
 import click
 from seismic.inventory.response import ResponseFactory
-import tempfile
-from collections import defaultdict
 from obspy import read_inventory
 
 sc3_converter_app = "fdsnxml2inv"
 sc3_converter_options = ("--quiet", "--formatted")
 
-CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
-@click.command(context_settings=CONTEXT_SETTINGS)
-@click.argument('src_path', type=click.Path('r'))
-@click.argument('dst_path', type=str)
-@click.option('--response-fdsnxml', default=None, 
-              type=click.Path('r'),
-              help="Inject 'bogus' responses from an FDSNXML file containing a valid response")
-def toSc3ml(src_path, dst_path, response_fdsnxml):
+
+def toSc3ml(src_path, dst_path, response_fdsnxml=None):
     """
     Convert file(s) in src_path from FDSN station XML to SC3ML and emit result(s) to dst_path.
 
@@ -47,9 +41,9 @@ def toSc3ml(src_path, dst_path, response_fdsnxml):
 
     if not os.path.exists(src_path):
         raise FileNotFoundError(src_path)
-    
+
     response = None
-    if(response_fdsnxml):
+    if response_fdsnxml is not None:
         rf = ResponseFactory()
         rf.CreateFromStationXML('resp', response_fdsnxml)
         response = rf.getResponse('resp')
@@ -143,5 +137,16 @@ def _reportConversion(success_files_list, failed_files_list):
             print("  " + f)
 
 
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+@click.command(context_settings=CONTEXT_SETTINGS)
+@click.argument('src_path', type=click.Path('r'))
+@click.argument('dst_path', type=str)
+@click.option('--response-fdsnxml', default=None, 
+              type=click.Path('r'),
+              help="Inject 'bogus' responses from an FDSNXML file containing a valid response")
+def main(src_path, dst_path, response_fdsnxml):
+    toSc3ml(src_path, dst_path, response_fdsnxml)
+
+
 if __name__ == "__main__":
-    toSc3ml()
+    main()  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
Main change here is moving the click decorators in fdsnxml_convert.py to a main() function rather than decorating toSc3ml(), since function toSc3ml() needs to be callable from engd2stxml.py script.
