### PR TITLE
Andrew medlin/pst 389 inventory iris merge

### DIFF
--- a/seismic/gps_corrections/README.md
+++ b/seismic/gps_corrections/README.md
@@ -4,7 +4,7 @@ This package provides a suite of tools for analysis of GPS clock correctness acr
 There are tools to identify the existence of a GPS clock error on a station, and for analyzing the
 clock errors to generate clock time corrections.
 
-The clock error identification script are automated batch scripts based on the following techniques:
+The clock error identification scripts are automated batch scripts based on the following techniques:
 * relative travel-time (TT) residuals
 * ambient noise cross-correlation between station pairs
 
@@ -14,7 +14,7 @@ functions to the clock error data, and exporting of the fitted functions to file
 
 ## Relative TT residual analysis
 
-Script `relative_tt_residuals_plotter.py` generate timeline plots of seismic travel time residual
+Script `relative_tt_residuals_plotter.py` generates timeline plots of seismic travel time residual
 analysis of one network relative to another network to identify potential GPS clock drift. Given an
 ensemble of events common to a pair of networks, for each station its travel-time residual for each
 event is subtracted from the same event on all common stations of another network, and all such
@@ -31,7 +31,7 @@ and reliable due to the number of aggregated events that get plotted.
 
 Example:
 
-`python relative_tt_residuals_plotter.py --network1 AU --networks2 OA`
+`python relative_tt_residuals_plotter.py --network1 AU --networks2 OA ensemble_20190428.p.txt`
 
 This generates a folder `OA_strict` containing a subfolder `AU,GE,IR,IU`. This means network OA has been
 analyzed against AU,GE,IR,IU. *Why all these other network codes (GE,IR,IU) when only AU was requested?*
@@ -74,7 +74,7 @@ time window of only about ~50 seconds for picking p-wave arrivals. Therefore usi
 TT residuals we can only detect drifts less than about 50 seconds. For larger clock errors,
 cross-correlation analysis is required.
 
-In many cases clocks drift gradually, so residual can effectively detect the onset of drift and the
+In many cases clocks drift gradually, so residuals can effectively detect the onset of drift and the
 drift rate. It can also detect clock jumps of less than 50 seconds, but cannot detect sudden clock
 jumps of more than 50 seconds.
 

--- a/seismic/inventory/engd2stxml.py
+++ b/seismic/inventory/engd2stxml.py
@@ -38,11 +38,9 @@ import obspy
 from obspy import read_inventory
 from obspy.core.inventory import Inventory
 from seismic.inventory.pdconvert import pd2Network
-# from seismic.inventory.plotting import saveNetworkLocalPlots
 from seismic.inventory.table_format import (TABLE_SCHEMA, TABLE_COLUMNS, PANDAS_MAX_TIMESTAMP,
                                             DEFAULT_START_TIMESTAMP, DEFAULT_END_TIMESTAMP)
 from seismic.inventory.iris_query import setTextEncoding, formResponseRequestUrl
-# from seismic.inventory.fdsnxml_convert import toSc3ml
 from seismic.inventory.inventory_util import NOMINAL_EARTH_RADIUS_KM, SORT_ORDERING
 
 PY2 = sys.version_info[0] < 3
@@ -50,11 +48,9 @@ PY2 = sys.version_info[0] < 3
 if PY2:
     import cStringIO as sio  # pylint: disable=import-error
     import io as bio
-    # import pathlib2 as pathlib  # pylint: disable=import-error
     import cPickle as pkl  # pylint: disable=import-error
 else:
     import io as sio
-    # import pathlib  # pylint: disable=import-error
     import pickle as pkl
     bio = sio
     basestring = str

--- a/seismic/inventory/fdsnxml_convert.py
+++ b/seismic/inventory/fdsnxml_convert.py
@@ -118,8 +118,8 @@ def _folderToSc3ml(src_folder, dst_folder):
                 # _fileToSc3ml(src_file, dst_file, response)
                 _fileToSc3ml(src_file, dst_file)
                 success_files.append(src_file)
-            except subprocess.CalledProcessError:
-                failed_files.append(src_file)
+            except (subprocess.CalledProcessError, OSError) as e:
+                failed_files.append((src_file, str(e)))
 
     return success_files, failed_files
 
@@ -139,8 +139,8 @@ def _reportConversion(success_files_list, failed_files_list):
         print("Successfully converted {} files to sc3ml".format(num_success))
     if num_failed > 0:
         print("Following {} files failed conversion:".format(num_failed))
-        for f in failed_files_list:
-            print("  " + f)
+        for f, e in failed_files_list:
+            print("  {} ({})".format(f, e))
 
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])

--- a/seismic/inventory/fdsnxml_convert.py
+++ b/seismic/inventory/fdsnxml_convert.py
@@ -63,7 +63,7 @@ def _fileToSc3ml(src_file, dst_file, response=None):
         raise FileExistsError("{} already exists as a folder".format(dst_file))
 
     # Inject responses
-    inv  = read_inventory(src_file)
+    inv = read_inventory(src_file)
     for n in inv.networks:
         for s in n.stations:
             if(not s.start_date): s.start_date = n.start_date

--- a/seismic/inventory/fdsnxml_convert.py
+++ b/seismic/inventory/fdsnxml_convert.py
@@ -36,7 +36,7 @@ def toSc3ml(src_path, dst_path, response_fdsnxml=None):
     :type dst_path: str or pathlib.Path
     :raises: OSError, FileNotFoundError, RuntimeError, FileExistsError
     """
-    if not _checkConverterAvailability():
+    if not sc3_conversion_available():
         raise OSError(2, "No such application found on path", sc3_converter_app)
 
     if not os.path.exists(src_path):
@@ -119,12 +119,13 @@ def _folderToSc3ml(src_folder, dst_folder, response=None):
     return success_files, failed_files
 
 
-def _checkConverterAvailability():
+def sc3_conversion_available():
     if (sys.version_info >= (3, 0)):
         from shutil import which
         return which(sc3_converter_app) is not None
     else:
         return True # assume it exists
+
 
 def _reportConversion(success_files_list, failed_files_list):
     num_success = len(success_files_list)

--- a/seismic/inventory/fdsnxml_convert.py
+++ b/seismic/inventory/fdsnxml_convert.py
@@ -91,8 +91,8 @@ def _fileToSc3ml(src_file, dst_file):
 def _makedirs(path, exist_ok=True):
     if (sys.version_info >= (3, 0)):
         os.makedirs(path, exist_ok=exist_ok)
-    else:
-        if not os.path.exists(path): os.makedirs(path)
+    elif not os.path.exists(path):
+        os.makedirs(path)
 
 
 def _folderToSc3ml(src_folder, dst_folder):

--- a/seismic/inventory/fdsnxml_convert.py
+++ b/seismic/inventory/fdsnxml_convert.py
@@ -9,17 +9,17 @@ Can be used as a standalone tool as well:
 import os
 import sys
 import subprocess
-# import tempfile
+import tempfile
 
 import click
-# from seismic.inventory.response import ResponseFactory
-# from obspy import read_inventory
+from seismic.inventory.response import ResponseFactory
+from obspy import read_inventory
 
 sc3_converter_app = "fdsnxml2inv"
 sc3_converter_options = ("--quiet", "--formatted")
 
 
-def toSc3ml(src_path, dst_path):
+def toSc3ml(src_path, dst_path, response_fdsnxml=None):
     """
     Convert file(s) in src_path from FDSN station XML to SC3ML and emit result(s) to dst_path.
 
@@ -34,6 +34,9 @@ def toSc3ml(src_path, dst_path):
     :type src_path: str or pathlib.Path
     :param dst_path: The destination path into which converted sc3ml file(s) are output.
     :type dst_path: str or pathlib.Path
+    :param response_fdsnxml: Path to existing for containing dummy response to insert into records
+        where instrument response is missing.
+    :type response_fdsnxml: str or Path
     :raises: OSError, FileNotFoundError, RuntimeError, FileExistsError
     """
     if not sc3_conversion_available():
@@ -42,42 +45,50 @@ def toSc3ml(src_path, dst_path):
     if not os.path.exists(src_path):
         raise FileNotFoundError(src_path)
 
-    # response = None
-    # if response_fdsnxml is not None:
-    #     rf = ResponseFactory()
-    #     rf.CreateFromStationXML('resp', response_fdsnxml)
-    #     response = rf.getResponse('resp')
+    response = None
+    if response_fdsnxml is not None:
+        rf = ResponseFactory()
+        rf.CreateFromStationXML('resp', response_fdsnxml)
+        response = rf.getResponse('resp')
 
     if os.path.isfile(src_path):
-        # _fileToSc3ml(src_path, dst_path, response)
-        _fileToSc3ml(src_path, dst_path)
-        _reportConversion([src_path], [])
+        _file_to_sc3ml(src_path, dst_path, response)
+        _report_conversion([src_path], [])
     elif os.path.isdir(src_path):
-        # _reportConversion(*_folderToSc3ml(src_path, dst_path, response))
-        _reportConversion(*_folderToSc3ml(src_path, dst_path))
+        _report_conversion(*_folder_to_sc3ml(src_path, dst_path, response))
     else:
         raise RuntimeError("Unsupported file type for {}".format(src_path))
 
 
-def _fileToSc3ml(src_file, dst_file):
+def _file_to_sc3ml(src_file, dst_file, response=None):
     assert os.path.isfile(src_file)
     if os.path.exists(dst_file) and os.path.isdir(dst_file):
         raise FileExistsError("{} already exists as a folder".format(dst_file))
 
-    # # Repair dates and inject responses if needed.
-    # inv = read_inventory(src_file)
-    # for n in inv.networks:
-    #     for s in n.stations:
-    #         if(not s.start_date): s.start_date = n.start_date
-    #         if(not s.end_date): s.end_date = n.end_date
-    #         for c in s.channels:
-    #             if(not c.start_date): c.start_date = s.start_date
-    #             if(not c.end_date): c.end_date = s.end_date
-    #             if(response and not c.response): c.response = response
-
-    #     fn = os.path.join(tempfile.gettempdir(), os.path.basename(src_file))
-    #     inv.write(fn, format='STATIONXML')
-    #     src_file = fn
+    # We only perform any of this data curation loop if the dummy response is not None.
+    if response is not None:
+        # Repair dates and inject responses if needed.
+        inv = read_inventory(src_file)
+        for n in inv.networks:
+            for s in n.stations:
+                if (not s.start_date):
+                    s.start_date = n.start_date
+                if (not s.end_date):
+                    s.end_date = n.end_date
+                for c in s.channels:
+                    if (not c.start_date):
+                        c.start_date = s.start_date
+                    if (not c.end_date):
+                        c.end_date = s.end_date
+                    if (not c.response):
+                        c.response = response
+                # end for
+            # end for
+        # end for
+        fn = os.path.join(tempfile.gettempdir(), os.path.basename(src_file))
+        inv.write(fn, format='STATIONXML')
+        src_file = fn
+    # end if
 
     cmd = [sc3_converter_app] + list(sc3_converter_options) + [src_file, dst_file]
     # Convert using system call
@@ -95,7 +106,7 @@ def _makedirs(path, exist_ok=True):
         os.makedirs(path)
 
 
-def _folderToSc3ml(src_folder, dst_folder):
+def _folder_to_sc3ml(src_folder, dst_folder, response=None):
     assert os.path.isdir(src_folder)
     if os.path.exists(dst_folder) and os.path.isfile(dst_folder):
         raise FileExistsError("{} already exists as a file".format(dst_folder))
@@ -115,8 +126,7 @@ def _folderToSc3ml(src_folder, dst_folder):
             _makedirs(dst_tree, exist_ok=True)
             dst_file = os.path.join(dst_tree, f)
             try:
-                # _fileToSc3ml(src_file, dst_file, response)
-                _fileToSc3ml(src_file, dst_file)
+                _file_to_sc3ml(src_file, dst_file, response)
                 success_files.append(src_file)
             except (subprocess.CalledProcessError, OSError) as e:
                 failed_files.append((src_file, str(e)))
@@ -125,14 +135,20 @@ def _folderToSc3ml(src_folder, dst_folder):
 
 
 def sc3_conversion_available():
+    """Check whether conversion to seiscomp3 format is available os this system.
+       Only works for Python 3, for Python 2 it always returns True (i.e. give it a try).
+
+    :return: True if conversion to sc3ml can be performed on this system, False otherwise.
+    :rtype: bool
+    """
     if (sys.version_info >= (3, 0)):
         from shutil import which
         return which(sc3_converter_app) is not None
     else:
-        return True # assume it exists
+        return True  # assume it exists
 
 
-def _reportConversion(success_files_list, failed_files_list):
+def _report_conversion(success_files_list, failed_files_list):
     num_success = len(success_files_list)
     num_failed = len(failed_files_list)
     if num_success > 0:
@@ -147,8 +163,11 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.command(context_settings=CONTEXT_SETTINGS)
 @click.argument('src_path', type=click.Path('r'))
 @click.argument('dst_path', type=str)
-def main(src_path, dst_path):
-    toSc3ml(src_path, dst_path)
+@click.option('--response-fdsnxml', default=None,
+              type=click.Path('r'),
+              help="Inject 'bogus' responses from an FDSNXML file containing a valid response")
+def main(src_path, dst_path, response_fdsnxml):
+    toSc3ml(src_path, dst_path, response_fdsnxml)
 
 
 if __name__ == "__main__":

--- a/seismic/inventory/generate_network_plots.py
+++ b/seismic/inventory/generate_network_plots.py
@@ -14,7 +14,7 @@ import os
 import sys
 import pandas as pd
 
-from seismic.inventory.plotting import saveNetworkLocalPlots, saveStationLocalPlots
+from seismic.inventory.plotting import save_network_local_plots, save_station_local_plots
 
 try:
     import tqdm
@@ -41,6 +41,6 @@ else:
     progressor = None
 
 # Save network plots to files
-saveNetworkLocalPlots(db, folder_name, progressor=progressor)
+save_network_local_plots(db, folder_name, progressor=progressor)
 if show_progress:
     pbar.close()

--- a/seismic/inventory/inventory_merge.py
+++ b/seismic/inventory/inventory_merge.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python
+"""Merge a master inventory (e.g. from IRIS) with custom inventories.
+"""
+
+import os
+import sys
+import datetime
+import pickle as pkl
+
+import click
+import numpy as np
+import pandas as pd
+import obspy
+from obspy import read_inventory
+
+from seismic.inventory.pdconvert import inventory2Dataframe
+from obspy.geodetics.base import locations2degrees
+
+from seismic.inventory.inventory_util import NOMINAL_EARTH_RADIUS_KM, SORT_ORDERING
+
+try:
+    import tqdm
+    show_progress = True
+except ImportError:
+    show_progress = False
+    print("Run 'pip install tqdm' to see progress bar.")
+
+# Pandas table display options to reduce aggressiveness of truncation. Due to size of data sometimes we
+# need to see more details in the table.
+pd.set_option('display.max_rows', 500)
+pd.set_option('display.max_columns', None)
+pd.set_option('display.max_colwidth', -1)
+pd.set_option('display.width', 240)
+
+PY2 = sys.version_info[0] < 3
+
+# Timestamp to be added to output file names, so that each run generates unique log files.
+rt_timestamp = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
+
+# Distance within which IRIS stations will be considered at same notional location as other stations
+# that match on other metadata axes.
+DIST_TOLERANCE_KM = 5.0
+
+# def removeIrisDuplicates(db_other, db_iris):
+#     """
+#     Remove stations which duplicate records in IRIS database.
+#     """
+#     if show_progress:
+#         pbar = tqdm.tqdm(total=len(db_other), ascii=True)
+#     removal_index = []
+#     with open("LOG_IRIS_DUPES_" + rt_timestamp + ".txt", 'w') as log:
+#         for (netcode, statcode), data in db_other.groupby(['NetworkCode', 'StationCode']):
+#             iris_query = iris_inv.select(network=netcode, station=statcode, channel="*HZ")
+#             if len(iris_query) <= 0:
+#                 # No IRIS record matching this station
+#                 if show_progress:
+#                     pbar.update(len(data))
+#                 continue
+#             # Pull out matching stations. Since some station codes have asterisk, which is interpreted as a wildcard
+#             # by the obspy query, we need to filter against matching exact statcode.
+#             matching_stations = [s for n in iris_query.networks for s in n.stations if s.code == statcode and n.code == netcode]
+#             iris_station0 = matching_stations[0]
+#             # Check that the set of stations from IRIS are themselves within the distance tolerance of one another.
+#             iris_stations_dist = [np.deg2rad(locations2degrees(iris_station0.latitude, iris_station0.longitude, s.latitude, s.longitude)) * NOMINAL_EARTH_RADIUS_KM
+#                                   for s in matching_stations]
+#             iris_stations_dist = np.array(iris_stations_dist)
+#             within_tolerance_mask = (iris_stations_dist < DIST_TOLERANCE_KM)
+#             if not np.all(within_tolerance_mask):
+#                 log.write("WARNING: Not all IRIS stations localized within distance tolerance for station code {0}.{1}. "
+#                           "Distances(km) = {2}\n".format(netcode, statcode, iris_stations_dist[~within_tolerance_mask]))
+#             # Compute cosine distances between this group's set of stations and the IRIS station location.
+#             ref_latlong = np.array([iris_station0.latitude, iris_station0.longitude])
+#             stations_latlong = data[["Latitude", "Longitude"]].values
+#             distfunc = lambda r: np.deg2rad(locations2degrees(ref_latlong[0], ref_latlong[1], r[0], r[1])) * NOMINAL_EARTH_RADIUS_KM  # noqa
+#             surface_dist = np.apply_along_axis(distfunc, 1, stations_latlong)
+#             # assert isinstance(surface_dist, np.ndarray)
+#             if not surface_dist.shape:
+#                 surface_dist = np.reshape(surface_dist, (1,))
+#             mask = (surface_dist < DIST_TOLERANCE_KM)
+#             if np.isscalar(mask):
+#                 mask = np.array([mask], ndmin=1)
+#             duplicate_index = np.array(data.index.tolist())[mask]
+#             if len(duplicate_index) < len(data):
+#                 # Disable false positive from pylint on following line
+#                 kept_station_distances = surface_dist[(~mask)]  # pylint: disable=invalid-unary-operand-type
+#                 log.write("WARNING: Some ISC stations outside distance tolerance of IRIS location for station {0}.{1}, not dropping. "
+#                           "(Possible issues with station date ranges?) Distances(km) = {2}\n".format(netcode, statcode, kept_station_distances))
+#             removal_index.extend(duplicate_index.tolist())
+#             if show_progress:
+#                 pbar.update(len(data))
+#     if show_progress:
+#         pbar.close()
+
+#     if removal_index:
+#         df.drop(removal_index, inplace=True)
+
+
+def prune_iris_duplicates(db_other, db_iris):
+    # Station codes and channel codes are reliable, but network codes and station/channel dates are not.
+    # Station lat/lon locations are approximately reliable.
+    # Therefore the merge method here matches records with matching station code, channel code and approximate
+    # location. For each match, we examine station dates, and discard any records of db_other that overlap
+    # with db_iris.
+    #
+    # db_iris is not changed by this function.
+
+    def earth_distance(row):
+        lat0 = row['Latitude_left']
+        long0 = row['Longitude_left']
+        lat1 = row['Latitude_right']
+        long1 = row['Longitude_right']
+        return np.deg2rad(locations2degrees(lat0, long0, lat1, long1)) * NOMINAL_EARTH_RADIUS_KM
+
+    db_other['Index'] = db_other.index
+    db_iris['Index'] = db_iris.index
+    df_m = db_other.reset_index().merge(db_iris, on=['StationCode', 'ChannelCode'], suffixes=('_left', '_right')
+                                        ).set_index('index')
+    dist = df_m.apply(earth_distance, axis=1)
+    df_m['Distance'] = dist
+    # Reorder columns for easier visual comparison
+    df_m = df_m[['NetworkCode_left', 'NetworkCode_right', 'StationCode', 'ChannelCode',
+                 'Latitude_left', 'Latitude_right', 'Longitude_left', 'Longitude_right', 'Distance',
+                 'Elevation_left', 'Elevation_right',
+                 'StationStart_left', 'StationStart_right', 'StationEnd_left', 'StationEnd_right',
+                 'ChannelStart_left', 'ChannelStart_right', 'ChannelEnd_left', 'ChannelEnd_right',
+                 'Index_left', 'Index_right']]
+
+    df_m = df_m[(df_m['Distance'] <= DIST_TOLERANCE_KM)]
+
+    # # Make sure that for those records that we keep from db_other, the network codes match those from IRIS
+    # # (irrespective of dates).
+    # db_other[(db_other.index == df_m['Index_left']), 'NetworkCode'] = df_m['NetworkCode_right']
+
+    # Identify which index values in df_m represent overlapping channel dates of IRIS and other data records.
+    # The dates that overlap are the records that we DON'T want to keep.
+    overlapping_dates = ((df_m['ChannelStart_left'] < df_m['ChannelEnd_right']) &
+                         (df_m['ChannelEnd_left'] > df_m['ChannelStart_right']))
+    index_to_keep = df_m.loc[~overlapping_dates, 'Index_left'].unique()
+
+    db_pruned = db_other.loc[index_to_keep]
+
+    return db_pruned
+
+def load_FDSN_station_xml(inventory_file):  # pylint: disable=invalid-name
+    """Load a FDSN stationxml file and convert to Pandas dataframe
+
+    :param inventory_file: [description]
+    :type inventory_file: str or path
+    """
+    if PY2:
+        import io
+        with io.open(inventory_file, mode='r', encoding='utf-8') as f:
+            obspy_inv = read_inventory(f)
+    else:
+        with open(inventory_file, mode='r', encoding='utf-8') as f:
+            obspy_inv = read_inventory(f)
+
+    db = inventory2Dataframe(obspy_inv)
+    return db
+
+
+@click.command()
+@click.option('--iris-inv', type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True), required=True,
+              help='IRIS inventory file in FDSN stationxml format. These records take precedence over custom files.')
+@click.option('--extra-inv', type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True), required=True,
+              help='Extra inventory file in FDSN stationxml format to merge with the IRIS inventory.')
+@click.option('--output-file', type=click.Path(exists=False, dir_okay=False), required=True,
+              help='Name of file to output final result to.')
+def main(iris_inv, extra_inv, output_file):
+
+    # Load IRIS inventory
+    if os.path.exists(os.path.splitext(iris_inv)[0] + ".pkl"):
+        with open(os.path.splitext(iris_inv)[0] + ".pkl", 'rb') as f:
+            db_iris = pkl.load(f)
+    else:
+        db_iris = load_FDSN_station_xml(iris_inv)
+        with open(os.path.splitext(iris_inv)[0] + ".pkl", 'wb') as f:
+            pkl.dump(db_iris, f, pkl.HIGHEST_PROTOCOL)
+
+    # Load custom inventory
+    if os.path.exists(os.path.splitext(extra_inv)[0] + ".pkl"):
+        with open(os.path.splitext(extra_inv)[0] + ".pkl", 'rb') as f:
+            db_other = pkl.load(f)
+    else:
+        db_other = load_FDSN_station_xml(extra_inv)
+        with open(os.path.splitext(extra_inv)[0] + ".pkl", 'wb') as f:
+            pkl.dump(db_other, f, pkl.HIGHEST_PROTOCOL)
+
+    print("Merging {} IRIS records with {} custom records".format(len(db_iris), len(db_other)))
+    num_before = len(db_other)
+    # removeIrisDuplicates(db_other, db_iris)
+    db_other = prune_iris_duplicates(db_other, db_iris)
+    if len(db_other) < num_before:
+        print("Removed {0}/{1} stations because they exist in IRIS".format(num_before - len(db_other), num_before))
+
+    # Merge db_iris and db_other, then sort by network, station, channel, etc...
+    db_merged = pd.concat([db_iris, db_other], sort=False)
+    db_merged.sort_values(SORT_ORDERING, inplace=True)
+    db_merged.reset_index(drop=True, inplace=True)
+
+    # Save merged to new index
+
+
+if __name__ == "__main__":
+    main()  # pylint: disable=no-value-for-parameter

--- a/seismic/inventory/inventory_merge.py
+++ b/seismic/inventory/inventory_merge.py
@@ -2,15 +2,15 @@
 """Merge a master inventory (e.g. from IRIS) with custom inventories.
 """
 
+# pylint: disable=too-many-locals
+
 import os
-import sys
 import datetime
 import pickle as pkl
 
 import click
 import numpy as np
 import pandas as pd
-# import obspy
 from obspy.core.inventory import Network, Station
 from obspy.geodetics.base import locations2degrees
 
@@ -37,70 +37,27 @@ rt_timestamp = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
 
 # Distance within which IRIS stations will be considered at same notional location as other stations
 # that match on other metadata axes.
-DIST_TOLERANCE_KM = 5.0
-
-# def removeIrisDuplicates(db_other, db_iris):
-#     """
-#     Remove stations which duplicate records in IRIS database.
-#     """
-#     if show_progress:
-#         pbar = tqdm.tqdm(total=len(db_other), ascii=True)
-#     removal_index = []
-#     with open("LOG_IRIS_DUPES_" + rt_timestamp + ".txt", 'w') as log:
-#         for (netcode, statcode), data in db_other.groupby(['NetworkCode', 'StationCode']):
-#             iris_query = iris_inv.select(network=netcode, station=statcode, channel="*HZ")
-#             if len(iris_query) <= 0:
-#                 # No IRIS record matching this station
-#                 if show_progress:
-#                     pbar.update(len(data))
-#                 continue
-#             # Pull out matching stations. Since some station codes have asterisk, which is interpreted as a wildcard
-#             # by the obspy query, we need to filter against matching exact statcode.
-#             matching_stations = [s for n in iris_query.networks for s in n.stations if s.code == statcode and n.code == netcode]
-#             iris_station0 = matching_stations[0]
-#             # Check that the set of stations from IRIS are themselves within the distance tolerance of one another.
-#             iris_stations_dist = [np.deg2rad(locations2degrees(iris_station0.latitude, iris_station0.longitude, s.latitude, s.longitude)) * NOMINAL_EARTH_RADIUS_KM
-#                                   for s in matching_stations]
-#             iris_stations_dist = np.array(iris_stations_dist)
-#             within_tolerance_mask = (iris_stations_dist < DIST_TOLERANCE_KM)
-#             if not np.all(within_tolerance_mask):
-#                 log.write("WARNING: Not all IRIS stations localized within distance tolerance for station code {0}.{1}. "
-#                           "Distances(km) = {2}\n".format(netcode, statcode, iris_stations_dist[~within_tolerance_mask]))
-#             # Compute cosine distances between this group's set of stations and the IRIS station location.
-#             ref_latlong = np.array([iris_station0.latitude, iris_station0.longitude])
-#             stations_latlong = data[["Latitude", "Longitude"]].values
-#             distfunc = lambda r: np.deg2rad(locations2degrees(ref_latlong[0], ref_latlong[1], r[0], r[1])) * NOMINAL_EARTH_RADIUS_KM  # noqa
-#             surface_dist = np.apply_along_axis(distfunc, 1, stations_latlong)
-#             # assert isinstance(surface_dist, np.ndarray)
-#             if not surface_dist.shape:
-#                 surface_dist = np.reshape(surface_dist, (1,))
-#             mask = (surface_dist < DIST_TOLERANCE_KM)
-#             if np.isscalar(mask):
-#                 mask = np.array([mask], ndmin=1)
-#             duplicate_index = np.array(data.index.tolist())[mask]
-#             if len(duplicate_index) < len(data):
-#                 # Disable false positive from pylint on following line
-#                 kept_station_distances = surface_dist[(~mask)]  # pylint: disable=invalid-unary-operand-type
-#                 log.write("WARNING: Some ISC stations outside distance tolerance of IRIS location for station {0}.{1}, not dropping. "
-#                           "(Possible issues with station date ranges?) Distances(km) = {2}\n".format(netcode, statcode, kept_station_distances))
-#             removal_index.extend(duplicate_index.tolist())
-#             if show_progress:
-#                 pbar.update(len(data))
-#     if show_progress:
-#         pbar.close()
-
-#     if removal_index:
-#         df.drop(removal_index, inplace=True)
+DIST_TOLERANCE_KM = 5.0  # pylint: disable=invalid-name
 
 
 def prune_iris_duplicates(db_other, db_iris):
-    # Station codes and channel codes are reliable, but network codes and station/channel dates are not.
-    # Station lat/lon locations are approximately reliable.
-    # Therefore the merge method here matches records with matching station code, channel code and approximate
-    # location. For each match, we examine station dates, and discard any records of db_other that overlap
-    # with db_iris.
-    #
-    # db_iris is not changed by this function.
+    """Prune the records out of db_other which duplicate records that exist in db_iris.
+
+    Filtering concepts:
+    Station codes and channel codes are reliable, but network codes and station/channel dates are not.
+    Station lat/lon locations are approximately reliable. Therefore the merge method here matches records
+    with matching station code, channel code and approximate location. For each match, we examine station dates,
+    and discard any records of db_other that overlap with db_iris.
+
+    db_iris is not changed by this function.
+
+    :param db_other: DataFrame containing metadata records of custom inventory
+    :type db_other: pandas.DataFrame
+    :param db_iris: DataFrame containing metadata records of IRIS inventory
+    :type db_iris: pandas.DataFrame
+    :return: DataFrame containing records from db_other which are unique and do not appear in IRIS.
+    :rtype: pandas.DataFrame
+    """
 
     def earth_distance(row):
         lat0 = row['Latitude_left']
@@ -141,9 +98,9 @@ def prune_iris_duplicates(db_other, db_iris):
 
 
 @click.command()
-@click.option('--iris-inv', type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True), required=True,
+@click.option('--iris-inv', type=click.Path(exists=True, dir_okay=False, readable=True), required=True,
               help='IRIS inventory file in FDSN stationxml format. These records take precedence over custom files.')
-@click.option('--custom-inv', type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True), required=True,
+@click.option('--custom-inv', type=click.Path(exists=True, dir_okay=False, readable=True), required=True,
               help='Custom inventory file in FDSN stationxml format to merge with the IRIS inventory.')
 @click.option('--output-file', type=click.Path(exists=False, dir_okay=False), required=True,
               help='Name of file to output final result to.')
@@ -151,12 +108,12 @@ def main(iris_inv, custom_inv, output_file, split_output_folder=None):
     """Merge an IRIS inventory with a custom inventory, filtering out any custom inventory records
        that duplicate IRIS records.
 
-    :param iris_inv: [description]
-    :type iris_inv: [type]
-    :param custom_inv: [description]
-    :type custom_inv: [type]
-    :param output_file: [description]
-    :type output_file: [type]
+    :param iris_inv: Station XML file from which to load IRIS inventory
+    :type iris_inv: str or Path to file
+    :param custom_inv: Station XML file with custom records to merge with IRIS inventory
+    :type custom_inv: str or Path to file
+    :param output_file: File name of output file which will contain merged IRIS and custom inventory.
+    :type output_file: str or Path to file
     """
 
     # Load IRIS inventory
@@ -232,10 +189,10 @@ def main(iris_inv, custom_inv, output_file, split_output_folder=None):
                         (db_other['Elevation'] == ele) &
                         (db_other['StationStart'] == sta_start) &
                         (db_other['ChannelStart'] == cha_start)
-                )
+                       )
                 if np.any(mask):
                     db_match = db_other[mask]
-                    assert len(db_match) == 1, 'Found multiple matching records, expected only one for {}'.format(db_match)
+                    assert len(db_match) == 1, 'Found multiple matches, expected only one for {}'.format(db_match)
                     add_network = True
                     num_added += 1
                     if show_progress:

--- a/seismic/inventory/inventory_merge.py
+++ b/seismic/inventory/inventory_merge.py
@@ -175,6 +175,7 @@ def main(iris_inv, custom_inv, output_file, split_output_folder=None):
                           site=station.site, creation_date=station.creation_date,
                           termination_date=station.termination_date, description=station.description,
                           comments=station.comments, start_date=station.start_date, end_date=station.end_date)
+            add_station = False
             for channel in station.channels:
                 lat = channel.latitude if channel.latitude else station.latitude
                 lon = channel.longitude if channel.longitude else station.longitude
@@ -194,12 +195,13 @@ def main(iris_inv, custom_inv, output_file, split_output_folder=None):
                     db_match = db_other[mask]
                     assert len(db_match) == 1, 'Found multiple matches, expected only one for {}'.format(db_match)
                     add_network = True
+                    add_station = True
                     num_added += 1
                     if show_progress:
                         pbar.set_description("Matched {}/{}".format(num_added, len(db_other)))
                     sta.channels.append(channel)
             # end for
-            if add_network:
+            if add_station:
                 net.stations.append(sta)
         # end for
         if add_network:

--- a/seismic/inventory/inventory_merge.py
+++ b/seismic/inventory/inventory_merge.py
@@ -10,13 +10,13 @@ import pickle as pkl
 import click
 import numpy as np
 import pandas as pd
-import obspy
-from obspy import read_inventory
-
-from seismic.inventory.pdconvert import inventory2Dataframe
+# import obspy
+from obspy.core.inventory import Network, Station
 from obspy.geodetics.base import locations2degrees
 
-from seismic.inventory.inventory_util import NOMINAL_EARTH_RADIUS_KM, SORT_ORDERING
+from seismic.inventory.pdconvert import inventory2Dataframe
+from seismic.inventory.inventory_split import split_inventory_by_network
+from seismic.inventory.inventory_util import load_station_xml, NOMINAL_EARTH_RADIUS_KM, SORT_ORDERING
 
 try:
     import tqdm
@@ -31,8 +31,6 @@ pd.set_option('display.max_rows', 500)
 pd.set_option('display.max_columns', None)
 pd.set_option('display.max_colwidth', -1)
 pd.set_option('display.width', 240)
-
-PY2 = sys.version_info[0] < 3
 
 # Timestamp to be added to output file names, so that each run generates unique log files.
 rt_timestamp = datetime.datetime.now().strftime("%Y%m%dT%H%M%S")
@@ -141,64 +139,128 @@ def prune_iris_duplicates(db_other, db_iris):
 
     return db_pruned
 
-def load_FDSN_station_xml(inventory_file):  # pylint: disable=invalid-name
-    """Load a FDSN stationxml file and convert to Pandas dataframe
-
-    :param inventory_file: [description]
-    :type inventory_file: str or path
-    """
-    if PY2:
-        import io
-        with io.open(inventory_file, mode='r', encoding='utf-8') as f:
-            obspy_inv = read_inventory(f)
-    else:
-        with open(inventory_file, mode='r', encoding='utf-8') as f:
-            obspy_inv = read_inventory(f)
-
-    db = inventory2Dataframe(obspy_inv)
-    return db
-
 
 @click.command()
 @click.option('--iris-inv', type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True), required=True,
               help='IRIS inventory file in FDSN stationxml format. These records take precedence over custom files.')
-@click.option('--extra-inv', type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True), required=True,
-              help='Extra inventory file in FDSN stationxml format to merge with the IRIS inventory.')
+@click.option('--custom-inv', type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True), required=True,
+              help='Custom inventory file in FDSN stationxml format to merge with the IRIS inventory.')
 @click.option('--output-file', type=click.Path(exists=False, dir_okay=False), required=True,
               help='Name of file to output final result to.')
-def main(iris_inv, extra_inv, output_file):
+def main(iris_inv, custom_inv, output_file, split_output_folder=None):
+    """Merge an IRIS inventory with a custom inventory, filtering out any custom inventory records
+       that duplicate IRIS records.
+
+    :param iris_inv: [description]
+    :type iris_inv: [type]
+    :param custom_inv: [description]
+    :type custom_inv: [type]
+    :param output_file: [description]
+    :type output_file: [type]
+    """
 
     # Load IRIS inventory
+    print("Loading {}...".format(iris_inv))
     if os.path.exists(os.path.splitext(iris_inv)[0] + ".pkl"):
         with open(os.path.splitext(iris_inv)[0] + ".pkl", 'rb') as f:
+            inv_iris = pkl.load(f)
             db_iris = pkl.load(f)
     else:
-        db_iris = load_FDSN_station_xml(iris_inv)
+        inv_iris = load_station_xml(iris_inv)
+        # and convert to Pandas dataframe
+        db_iris = inventory2Dataframe(inv_iris)
         with open(os.path.splitext(iris_inv)[0] + ".pkl", 'wb') as f:
+            pkl.dump(inv_iris, f, pkl.HIGHEST_PROTOCOL)
             pkl.dump(db_iris, f, pkl.HIGHEST_PROTOCOL)
 
     # Load custom inventory
-    if os.path.exists(os.path.splitext(extra_inv)[0] + ".pkl"):
-        with open(os.path.splitext(extra_inv)[0] + ".pkl", 'rb') as f:
+    print("Loading {}...".format(custom_inv))
+    if os.path.exists(os.path.splitext(custom_inv)[0] + ".pkl"):
+        with open(os.path.splitext(custom_inv)[0] + ".pkl", 'rb') as f:
+            inv_other = pkl.load(f)
             db_other = pkl.load(f)
     else:
-        db_other = load_FDSN_station_xml(extra_inv)
-        with open(os.path.splitext(extra_inv)[0] + ".pkl", 'wb') as f:
+        inv_other = load_station_xml(custom_inv)
+        # and convert to Pandas dataframe
+        db_other = inventory2Dataframe(inv_other)
+        with open(os.path.splitext(custom_inv)[0] + ".pkl", 'wb') as f:
+            pkl.dump(inv_other, f, pkl.HIGHEST_PROTOCOL)
             pkl.dump(db_other, f, pkl.HIGHEST_PROTOCOL)
 
-    print("Merging {} IRIS records with {} custom records".format(len(db_iris), len(db_other)))
+    print("Merging {} IRIS records with {} custom records...".format(len(db_iris), len(db_other)))
     num_before = len(db_other)
     # removeIrisDuplicates(db_other, db_iris)
     db_other = prune_iris_duplicates(db_other, db_iris)
+    db_other.sort_values(SORT_ORDERING, inplace=True)
+    db_other.reset_index(drop=True, inplace=True)
     if len(db_other) < num_before:
         print("Removed {0}/{1} stations because they exist in IRIS".format(num_before - len(db_other), num_before))
+    print("{} custom records remaining".format(len(db_other)))
 
-    # Merge db_iris and db_other, then sort by network, station, channel, etc...
-    db_merged = pd.concat([db_iris, db_other], sort=False)
-    db_merged.sort_values(SORT_ORDERING, inplace=True)
-    db_merged.reset_index(drop=True, inplace=True)
+    # Merge inv_other into inv_iris, only keeping the records of inv_other that are present in db_other
+    inv_merged = inv_iris  # Note: this aliases inv_iris, it does not make a copy.
+    print("Filtering {} records and merging with IRIS...".format(custom_inv))
+    num_added = 0
+    if show_progress:
+        num_entries = sum(len(station.channels) for network in inv_other.networks for station in network.stations)
+        pbar = tqdm.tqdm(total=num_entries, ascii=True)
+        pbar.set_description("Matched {}/{}".format(num_added, len(db_other)))
+    for network in inv_other.networks:
+        # Duplicate network data, but keep stations empty
+        net = Network(network.code, stations=[], description=network.description, comments=network.comments,
+                      start_date=network.start_date, end_date=network.end_date)
+        add_network = False
+        for station in network.stations:
+            if show_progress:
+                pbar.update(len(station.channels))
+            # Duplicate station data, but keep channels empty
+            sta = Station(station.code, station.latitude, station.longitude, station.elevation, channels=[],
+                          site=station.site, creation_date=station.creation_date,
+                          termination_date=station.termination_date, description=station.description,
+                          comments=station.comments, start_date=station.start_date, end_date=station.end_date)
+            for channel in station.channels:
+                lat = channel.latitude if channel.latitude else station.latitude
+                lon = channel.longitude if channel.longitude else station.longitude
+                ele = channel.elevation if channel.elevation else station.elevation
+                sta_start = np.datetime64(station.start_date)
+                cha_start = np.datetime64(channel.start_date)
+                mask = ((db_other['NetworkCode'] == network.code) &
+                        (db_other['StationCode'] == station.code) &
+                        (db_other['ChannelCode'] == channel.code) &
+                        (db_other['Latitude'] == lat) &
+                        (db_other['Longitude'] == lon) &
+                        (db_other['Elevation'] == ele) &
+                        (db_other['StationStart'] == sta_start) &
+                        (db_other['ChannelStart'] == cha_start)
+                )
+                if np.any(mask):
+                    db_match = db_other[mask]
+                    assert len(db_match) == 1, 'Found multiple matching records, expected only one for {}'.format(db_match)
+                    add_network = True
+                    num_added += 1
+                    if show_progress:
+                        pbar.set_description("Matched {}/{}".format(num_added, len(db_other)))
+                    sta.channels.append(channel)
+            # end for
+            if add_network:
+                net.stations.append(sta)
+        # end for
+        if add_network:
+            inv_merged += net
+    # end for
+    if show_progress:
+        pbar.close()
 
-    # Save merged to new index
+    print("Added {} custom records to IRIS inventory".format(num_added))
+
+    # Write merged inventory text file in FDSN stationxml inventory format.
+    print("Writing merged inventory to {}".format(output_file))
+    inv_merged.write(output_file, format="stationxml")
+    inv_merged.write(os.path.splitext(output_file)[0] + ".txt", format="stationtxt")
+
+    if split_output_folder is not None:
+        print("Writing separate network files to folder {}".format(split_output_folder))
+        split_inventory_by_network(inv_merged, split_output_folder)
 
 
 if __name__ == "__main__":

--- a/seismic/inventory/inventory_split.py
+++ b/seismic/inventory/inventory_split.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+"""Split a station inventory file into a separate file per network.
+"""
+
+import os
+import sys
+
+import click
+from obspy.core.inventory import Inventory
+
+from seismic.inventory.inventory_util import load_station_xml
+from seismic.inventory.fdsnxml_convert import sc3_conversion_available, toSc3ml
+
+PY2 = sys.version_info[0] < 3  # pylint: disable=invalid-name
+
+if PY2:
+    import pathlib2 as pathlib  # pylint: disable=import-error
+else:
+    import pathlib  # pylint: disable=import-error
+
+try:
+    import tqdm
+    show_progress = True
+except ImportError:
+    show_progress = False
+    print("Run 'pip install tqdm' to see progress bar.")
+
+
+def split_inventory_by_network(obspy_inv, output_folder, sc3ml_convert=False):
+
+    pathlib.Path(output_folder).mkdir(exist_ok=True)
+
+    if show_progress:
+        pbar = tqdm.tqdm(total=len(obspy_inv.networks), ascii=True)
+        std_print = pbar.write
+    else:
+        std_print = print
+
+    for network in obspy_inv:
+        pbar.update()
+        net_inv = Inventory(networks=[network], source=obspy_inv.source)
+        fname = "network_{}.xml".format(network.code)
+        try:
+            net_inv.write(os.path.join(output_folder, fname), format="stationxml", validate=True)
+        except Exception as e:
+            std_print(e)
+            std_print("FAILED writing file {0} for network {1}, continuing".format(fname, network.code))
+            continue
+    if show_progress:
+        pbar.close()
+
+    # Perform sc3ml conversion if requested and if supported.
+    if sc3ml_convert and sc3_conversion_available():
+        sc3ml_output_folder = output_folder + "_sc3ml"
+        try:
+            toSc3ml(output_folder, sc3ml_output_folder)
+        except OSError:
+            print("WARNING: Unable to convert to sc3ml!")
+            if os.path.isdir(sc3ml_output_folder):
+                import uuid
+                print("         Renaming {} to avoid accidental use!".format(sc3ml_output_folder))
+                stashed_name = sc3ml_output_folder + ".BAD." + str(uuid.uuid4())[-8:]
+                os.rename(sc3ml_output_folder, stashed_name)
+
+
+@click.command()
+@click.option('--inv-file', type=click.Path(exists=True, file_okay=True, dir_okay=False, readable=True), required=True,
+              help='Station inventory to be split. This file is not changed by the script.')
+@click.option('--output-folder', type=click.Path(exists=False, dir_okay=True), required=True,
+              help='Folder where per-network station xml files will be generated.')
+@click.option('--sc3ml', is_flag=True, help='Try to convert output files to sc3ml format if possible using seiscomp3.')
+def main(inv_file, output_folder, sc3ml=False):
+    print("Loading file {}".format(inv_file))
+    stn_inventory = load_station_xml(inv_file)
+    print("Splitting inventory into folder {}".format(output_folder))
+    split_inventory_by_network(stn_inventory, output_folder, sc3ml_convert=sc3ml)
+
+
+if __name__ == "__main__":
+    main()  # pylint: disable=no-value-for-parameter

--- a/seismic/inventory/inventory_split.py
+++ b/seismic/inventory/inventory_split.py
@@ -2,6 +2,8 @@
 """Split a station inventory file into a separate file per network.
 """
 
+from __future__ import print_function
+
 import os
 import sys
 

--- a/seismic/inventory/inventory_split.py
+++ b/seismic/inventory/inventory_split.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 
 import os
 import sys
+from collections import defaultdict
 
 import click
 from obspy.core.inventory import Inventory
@@ -46,12 +47,16 @@ def split_inventory_by_network(obspy_inv, output_folder, validate=False):
     else:
         std_print = print
 
+    # Since duplicate network codes can occur, we ensure that output file names are unique by keeping an instance
+    # count for the occurrences of each network, and appending this to the file name.
+    network_count = defaultdict(int)
     for network in obspy_inv:
         if show_progress:
             pbar.update()
             pbar.set_description("Network {}".format(network.code))
         net_inv = Inventory(networks=[network], source=obspy_inv.source)
-        fname = "network_{}.xml".format(network.code)
+        fname = "network_{}_{}.xml".format(network.code, network_count[network.code])
+        network_count[network.code] += 1
         try:
             net_inv.write(os.path.join(output_folder, fname), format="stationxml", validate=validate)
         except Exception as e:

--- a/seismic/inventory/inventory_split.py
+++ b/seismic/inventory/inventory_split.py
@@ -27,7 +27,15 @@ except ImportError:
 
 
 def split_inventory_by_network(obspy_inv, output_folder, validate=False):
+    """Export a station XML file per network for each network in given obspy Inventory.
 
+    :param obspy_inv: Obspy Inventory containing the networks to export to file.
+    :type obspy_inv: obspy.core.inventory.inventory.Inventory
+    :param output_folder: Folder in which to output the per-network XML files. Will be created if doesn't yet exist.
+    :type output_folder: str or Path
+    :param validate: Whether to validate the station data on write, defaults to False
+    :type validate: bool, optional
+    """
     pathlib.Path(output_folder).mkdir(exist_ok=True)
 
     if show_progress:
@@ -59,6 +67,8 @@ def split_inventory_by_network(obspy_inv, output_folder, validate=False):
               help='Folder where per-network station xml files will be generated.')
 @click.option('--sc3ml', is_flag=True, help='Try to convert output files to sc3ml format if possible using seiscomp3.')
 def main(inv_file, output_folder, sc3ml=False):
+    """Main function.
+    """
     print("Loading file {}".format(inv_file))
     stn_inventory = load_station_xml(inv_file)
     print("Splitting inventory into folder {}".format(output_folder))

--- a/seismic/inventory/inventory_split.py
+++ b/seismic/inventory/inventory_split.py
@@ -26,7 +26,7 @@ except ImportError:
     print("Run 'pip install tqdm' to see progress bar.")
 
 
-def split_inventory_by_network(obspy_inv, output_folder, sc3ml_convert=False):
+def split_inventory_by_network(obspy_inv, output_folder, sc3ml_convert=False, validate=False):
 
     pathlib.Path(output_folder).mkdir(exist_ok=True)
 
@@ -37,13 +37,15 @@ def split_inventory_by_network(obspy_inv, output_folder, sc3ml_convert=False):
         std_print = print
 
     for network in obspy_inv:
-        pbar.update()
+        if show_progress:
+            pbar.update()
+            pbar.set_description("Network {}".format(network.code))
         net_inv = Inventory(networks=[network], source=obspy_inv.source)
         fname = "network_{}.xml".format(network.code)
         try:
-            net_inv.write(os.path.join(output_folder, fname), format="stationxml", validate=True)
+            net_inv.write(os.path.join(output_folder, fname), format="stationxml", validate=validate)
         except Exception as e:
-            std_print(e)
+            std_print(str(e))
             std_print("FAILED writing file {0} for network {1}, continuing".format(fname, network.code))
             continue
     if show_progress:

--- a/seismic/inventory/inventory_util.py
+++ b/seismic/inventory/inventory_util.py
@@ -1,5 +1,31 @@
 #!/usr/bin/env python
+"""Utility functions and constants shared amongst inventory management modules.
+"""
+
+import sys
+
+from obspy import read_inventory
+
+PY2 = sys.version_info[0] < 3  # pylint: disable=invalid-name
 
 NOMINAL_EARTH_RADIUS_KM = 6378.1370  # pylint: disable=invalid-name
 
-SORT_ORDERING = ['NetworkCode', 'StationCode', 'StationStart', 'StationEnd', 'ChannelCode', 'ChannelStart', 'ChannelEnd']  # pylint: disable=invalid-name
+SORT_ORDERING = ['NetworkCode', 'StationCode', 'StationStart', 'StationEnd',  # pylint: disable=invalid-name
+                 'ChannelCode', 'ChannelStart', 'ChannelEnd']
+
+
+def load_station_xml(inventory_file):
+    """Load a stationxml file
+
+    :param inventory_file: [description]
+    :type inventory_file: str or path
+    """
+    if PY2:
+        import io
+        with io.open(inventory_file, mode='r', encoding='utf-8') as f:
+            obspy_inv = read_inventory(f)
+    else:
+        with open(inventory_file, mode='r', encoding='utf-8') as f:
+            obspy_inv = read_inventory(f)
+
+    return obspy_inv

--- a/seismic/inventory/inventory_util.py
+++ b/seismic/inventory/inventory_util.py
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+NOMINAL_EARTH_RADIUS_KM = 6378.1370  # pylint: disable=invalid-name
+
+SORT_ORDERING = ['NetworkCode', 'StationCode', 'StationStart', 'StationEnd', 'ChannelCode', 'ChannelStart', 'ChannelEnd']  # pylint: disable=invalid-name

--- a/seismic/inventory/pdconvert.py
+++ b/seismic/inventory/pdconvert.py
@@ -110,6 +110,7 @@ def inventory2Dataframe(inv_object, show_progress=True):
         num_entries = sum(len(station.channels) for network in inv_object.networks for station in network.stations)
         pbar = tqdm.tqdm(total=num_entries, ascii=True)
 
+    max_end_timestamp = np.datetime64(str(PANDAS_MAX_TIMESTAMP), 's')
     d = defaultdict(list)
     for network in inv_object.networks:
         for station in network.stations:
@@ -125,10 +126,10 @@ def inventory2Dataframe(inv_object, show_progress=True):
                 d['Longitude'].append(lon)
                 d['Elevation'].append(ele)
                 d['StationStart'].append(np.datetime64(station.start_date))
-                d['StationEnd'].append(np.datetime64(station.end_date))
+                d['StationEnd'].append(min(np.datetime64(station.end_date, 's'), max_end_timestamp))
                 d['ChannelCode'].append(channel.code)
                 d['ChannelStart'].append(np.datetime64(channel.start_date))
-                d['ChannelEnd'].append(np.datetime64(channel.end_date))
+                d['ChannelEnd'].append(min(np.datetime64(channel.end_date, 's'), max_end_timestamp))
     if show_progress:
         pbar.close()
     df = pd.DataFrame.from_dict(d)

--- a/seismic/inventory/pdconvert.py
+++ b/seismic/inventory/pdconvert.py
@@ -4,15 +4,16 @@ Helper functions for converting between Pandas dataframe and FDSN Inventory,
 Network, Station and Channel objects.
 """
 
+# pylint: disable=too-many-locals
+
 from collections import defaultdict
 import numpy as np
 import pandas as pd
 
-from obspy import read_inventory
 from obspy.core import utcdatetime
-from obspy.core.inventory import Inventory, Network, Station, Channel, Site
+from obspy.core.inventory import Network, Station, Channel, Site
 
-from seismic.inventory.table_format import TABLE_SCHEMA, TABLE_COLUMNS, PANDAS_MAX_TIMESTAMP
+from seismic.inventory.table_format import TABLE_COLUMNS, PANDAS_MAX_TIMESTAMP
 
 
 def pd2Station(statcode, station_df, instrument_register=None):
@@ -24,7 +25,7 @@ def pd2Station(statcode, station_df, instrument_register=None):
     :param station_df: Dataframe containing records for a single station code.
     :type station_df: pandas.DataFrame conforming to table_format.TABLE_SCHEMA
     :param instrument_register: Dictionary of nominal instrument responses indexed by channel code, defaults to None
-    :param instrument_register: dict of {str, Instrument(obspy.core.inventory.util.Equipment, 
+    :param instrument_register: dict of {str, Instrument(obspy.core.inventory.util.Equipment,
         obspy.core.inventory.response.Response)}, optional
     :return: Station object containing the station information from the dataframe
     :rtype: obspy.core.inventory.station.Station
@@ -77,7 +78,7 @@ def pd2Network(netcode, network_df, instrument_register, progressor=None):
     :param network_df: Dataframe containing records for a single network code.
     :type network_df: pandas.DataFrame conforming to table_format.TABLE_SCHEMA
     :param instrument_register: Dictionary of nominal instrument responses indexed by channel code, defaults to None
-    :param instrument_register: dict of {str, Instrument(obspy.core.inventory.util.Equipment, 
+    :param instrument_register: dict of {str, Instrument(obspy.core.inventory.util.Equipment,
         obspy.core.inventory.response.Response)}, optional
     :param progressor: Progress bar functor to receive progress updates, defaults to None
     :param progressor: Callable object receiving incremental update on progress, optional

--- a/seismic/inventory/plotting.py
+++ b/seismic/inventory/plotting.py
@@ -4,11 +4,12 @@
 
 import os
 import sys
-import pandas as pd
-from seismic.inventory.pdconvert import pd2Network
+from collections import defaultdict
+
 from obspy.core.inventory import Inventory
 import matplotlib.pyplot as plt
-from collections import defaultdict
+
+from seismic.inventory.pdconvert import pd2Network
 
 if sys.version_info[0] < 3:
     import pathlib2 as pathlib  # pylint: disable=import-error
@@ -18,7 +19,7 @@ else:
 no_instruments = defaultdict(lambda: None)
 
 
-def saveNetworkLocalPlots(df, plot_folder, progressor=None, include_stations_list=True):
+def save_network_local_plots(df, plot_folder, progressor=None, include_stations_list=True):
     """
     Save visual map plot per network, saved to file netcode.png.
 
@@ -38,9 +39,10 @@ def saveNetworkLocalPlots(df, plot_folder, progressor=None, include_stations_lis
         net = pd2Network(netcode, data, no_instruments)
         plot_fname = os.path.join(dest_path, netcode + ".png")
         try:
-            fig = net.plot(projection="local", resolution="l", outfile=plot_fname, continent_fill_color="#e0e0e0", water_fill_color="#d0d0ff", color="#c08080")
+            fig = net.plot(projection="local", resolution="l", outfile=plot_fname, continent_fill_color="#e0e0e0",
+                           water_fill_color="#d0d0ff", color="#c08080")
             plt.close(fig)
-        except:
+        except Exception:
             failed.append(netcode)
 
         if include_stations_list:
@@ -57,7 +59,7 @@ def saveNetworkLocalPlots(df, plot_folder, progressor=None, include_stations_lis
         print("SUCCESS!")
 
 
-def saveStationLocalPlots(df, plot_folder, progressor=None, include_stations_list=True):
+def save_station_local_plots(df, plot_folder, progressor=None, include_stations_list=True):
     """
     Save visual map plot per station, saved to file netcode.stationcode.png.
 
@@ -78,9 +80,10 @@ def saveStationLocalPlots(df, plot_folder, progressor=None, include_stations_lis
         station_name = ".".join([netcode, statcode])
         plot_fname = os.path.join(dest_path, station_name + ".png")
         try:
-            fig = net.plot(projection="local", resolution="l", outfile=plot_fname, continent_fill_color="#e0e0e0", water_fill_color="#d0d0ff", color="#c08080")
+            fig = net.plot(projection="local", resolution="l", outfile=plot_fname, continent_fill_color="#e0e0e0",
+                           water_fill_color="#d0d0ff", color="#c08080")
             plt.close(fig)
-        except:
+        except Exception:
             failed.append(station_name)
 
         if include_stations_list:

--- a/seismic/inventory/update_iris_inventory.py
+++ b/seismic/inventory/update_iris_inventory.py
@@ -99,7 +99,6 @@ def update_iris_station_xml(output_file, output_format, options=None):
         except:
             cleanup(ifile.name)
             raise
-
         cleanup(ifile.name)
     elif output_format == 'FDSN':
         with open(output_file, 'w') as f:

--- a/seismic/inventory/update_iris_inventory.py
+++ b/seismic/inventory/update_iris_inventory.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python
 """Automatically update IRIS-ALL.xml file from IRIS web portal.
 
-   IRIS-ALL.xml file is saved as Seiscomp3 station xml.
+   Outout file is saved as FDSN station xml.
    Script also generates human readable form as IRIS-ALL.txt.
-   Requires seiscomp3 to be available in the system path.
 
    Example usages:
    ---------------
@@ -19,19 +18,14 @@
 
 import os
 import sys
-
-import requests as req
-import tempfile as tmp
-import subprocess
 import argparse
 import time
 import re
+
+import requests as req
 from seismic.inventory.iris_query import formChannelRequestUrl, setTextEncoding
-from seismic.inventory.fdsnxml_convert import toSc3ml
 
-
-DEFAULT_OUTPUT_FILE = "IRIS-ALL.xml"
-OUTPUT_FORMATS = ["SC3", "FDSN"]
+default_output_file = "IRIS-ALL.xml"
 
 # Dictionary of known illegal XML elements that obspy will reject if ingested. All such substrings
 # are replaced with their replacement prior to ingestion into obspy.
@@ -53,77 +47,51 @@ def cleanup(tmp_filename):
     """
     try:
         os.remove(tmp_filename)
-    except:
+    except OSError:
         print("WARNING: Failed to remove temporary file " + tmp_filename)
 
 
-def update_iris_station_xml(output_file, output_format, sc3_compatible,  options=None):
+def update_iris_station_xml(output_file, options=None):
     """
     Pull the latest IRIS complete station inventory (down to station level, not including
-    instrument responses) from IRIS web service and save to file in chosen format.
+    instrument responses) from IRIS web service and save to file in FDSN station xml format.
 
     :param output_file: Destination file to generate
     :type output_file: str
-    :param output_format: Destination file output format
-    :type output_format: str
     :param options: Filtering options for network, station and channel codes, defaults to None
     :param options: Python dict of key-values pairs matching command line options, optional
     """
-    assert output_format in OUTPUT_FORMATS
     iris_url = formChannelRequestUrl() if options is None else formChannelRequestUrl(**options)
     # Download latest IRIS station database as FDSN station xml.
     try:
         print("Requesting data from server...")
         iris = req.get(iris_url)
         setTextEncoding(iris)
-    except:
+    except req.exceptions.RequestException:
         print("FAILED to retrieve URL content at " + iris_url)
         return
 
     # Repair errors with IRIS data
-    sc3_format = (output_format == 'SC3')
     print("Correcting known data errors...")
-    iris_fixed = repair_iris_metadata(iris, sc3_compatible=(sc3_format or sc3_compatible))
+    iris_fixed = repair_iris_metadata(iris)
+    # Close the query to free resources
     iris.close()
 
-    if sc3_format:
-        try:
-            # Since there are not available Python bindings for the conversion, we have to dump FDSN stxml to file
-            # first, then convert to seiscomp3 stxml inventory using system call.
-            ifile = tmp.NamedTemporaryFile("w", delete=False)
-            ifile.write(iris_fixed)
-            ifile.close()
-            # Convert using helper module
-            print("Converting to SC3 format...")
-            toSc3ml(ifile.name, output_file)
-            print("Successfully updated file " + output_file)
-        except:
-            cleanup(ifile.name)
-            raise
-        cleanup(ifile.name)
-    elif output_format == 'FDSN':
-        with open(output_file, 'w') as f:
-            f.write(iris_fixed)
-    else:
-        assert False, "Unknown output format {}".format(output_format)
+    with open(output_file, 'w') as f:
+        f.write(iris_fixed, format='stationxml')
 
     # Create human-readable text form of the IRIS station inventory (Pandas stringified table)
     output_txt = os.path.splitext(output_file)[0] + ".txt"
     regenerate_human_readable(iris_fixed, output_txt)
 
 
-def repair_iris_metadata(iris, sc3_compatible=False):
+def repair_iris_metadata(iris):
     """Perform text subtitutions to fix known errors in station xml returned from IRIS.
-       If sc3_compatible:
-       * Add a non-empty nominal instrument response where missing.
-       * Replace empty station and channel dates with dates based on parent.
 
-    :param iris: [description]
-    :type iris: [type]
-    :param sc3_compatible: [description]
-    :type sc3_compatible: [type]
-    :return: [description]
-    :rtype: [type]
+    :param iris: Response to IRIS query request containing response text
+    :type iris: requests.models.Response
+    :return: The text from the response with known faulty data substituted with fixed data.
+    :rtype: str (Python 3) or unicode (Python 2)
     """
 
     def repair_match(match):
@@ -135,10 +103,6 @@ def repair_iris_metadata(iris, sc3_compatible=False):
     # This code repairs illegal data matching KNOWN_ILLEGAL_ELEMENTS_PATTERNS from iris.text
     matcher = re.compile("|".join(list(KNOWN_ILLEGAL_ELEMENTS_PATTERNS.keys())))
     iris_text_fixed = matcher.sub(repair_match, iris.text)
-
-    if sc3_compatible:
-        # TODO: functionalize the response and date cleanup code from fdsnxml_convert.py and apply here.
-        pass
 
     return iris_text_fixed
 
@@ -169,9 +133,9 @@ def regenerate_human_readable(iris_data, outfile):
     try:
         station_inv = read_inventory(obspy_input)
     except:
-        DUMPFILE = 'fdsn_stn_inv_dump.xml'
-        print("FAILED ingesting server response into obspy, dumping server response string to " + DUMPFILE)
-        with open(DUMPFILE, 'w') as f:
+        dumpfile = 'fdsn_stn_inv_dump.xml'
+        print("FAILED ingesting server response into obspy, dumping server response string to " + dumpfile)
+        with open(dumpfile, 'w') as f:
             f.write(iris_str.decode('utf-8'))
         raise
 
@@ -192,22 +156,14 @@ if __name__ == "__main__":
     parser.add_argument("-s", "--statmask", help="Filter mask to apply to station codes. "
                         "Filter strings should not include quotation marks.")
     parser.add_argument("-c", "--chanmask", help="Filter mask to apply to channel codes.")
-    parser.add_argument("-o", "--output", help="Name of output file.", default=DEFAULT_OUTPUT_FILE)
-    parser.add_argument("-f", "--format", default="SC3", help="Output format, from {}".format(OUTPUT_FORMATS))
-    parser.add_argument("--sc3-compatible", action="store_true",
-                        help="Make sure output is patched for SC3 compatibility (regardless of output format")
+    parser.add_argument("-o", "--output", help="Name of output file.", default=default_output_file)
     args = vars(parser.parse_args())
     filter_args = {k: v for k, v in args.items() if v is not None and k in ["netmask", "statmask", "chanmask"]}
     output_filename = args['output']
-    output_format = args['format']
-    sc3_compat = args['sc3_compatible']
-    if output_format not in OUTPUT_FORMATS:
-        print("Allowed output formats: {}".format(OUTPUT_FORMATS))
-        exit(0)
-    print("Destination file: " + output_filename + " (" + output_format + " format)")
+    print("Destination file: " + output_filename)
     time.sleep(1)
 
     if filter_args:
-        update_iris_station_xml(output_filename, output_format, sc3_compat, filter_args)
+        update_iris_station_xml(output_filename, filter_args)
     else:
-        update_iris_station_xml(output_filename, output_format, sc3_compat)
+        update_iris_station_xml(output_filename)

--- a/seismic/inventory/update_iris_inventory.py
+++ b/seismic/inventory/update_iris_inventory.py
@@ -31,14 +31,17 @@ from seismic.inventory.fdsnxml_convert import toSc3ml
 
 
 DEFAULT_OUTPUT_FILE = "IRIS-ALL.xml"
+OUTPUT_FORMATS = ["SC3", "FDSN"]
 
-# Tuple of known illegal XML elements that obspy will reject if ingested. All such substrings
-# are removed prior to ingestion into obspy.
-KNOWN_ILLEGAL_ELEMENTS_PATTERNS = (
-    r"<Azimuth>360\.[1-9]\d*</Azimuth>",
-    r"<Azimuth>36[1-9](\.\d*)?</Azimuth>",
-    r"<Azimuth>3[7-9]\d(\.\d*)?</Azimuth>",
-)
+# Dictionary of known illegal XML elements that obspy will reject if ingested. All such substrings
+# are replaced with their replacement prior to ingestion into obspy.
+KNOWN_ILLEGAL_ELEMENTS_PATTERNS = {  # pylint: disable=invalid-name
+    r"<Azimuth>360\.[1-9]\d*</Azimuth>": "",
+    r"<Azimuth>36[1-9](\.\d*)?</Azimuth>": "",
+    r"<Azimuth>3[7-9]\d(\.\d*)?</Azimuth>": "",
+    r"<Azimuth>-90</Azimuth>": "",
+    r"<Latitude>-90.878944</Latitude>": r"<Latitude>-90</Latitude>",
+}
 
 
 def cleanup(tmp_filename):
@@ -54,16 +57,19 @@ def cleanup(tmp_filename):
         print("WARNING: Failed to remove temporary file " + tmp_filename)
 
 
-def updateIrisStationXml(output_file, options=None):
+def update_iris_station_xml(output_file, output_format, options=None):
     """
     Pull the latest IRIS complete station inventory (down to station level, not including
-    instrument responses) from IRIS web service and save to file in sc3ml format.
+    instrument responses) from IRIS web service and save to file in chosen format.
 
-    :param output_file: Destination sc3ml file to generate
+    :param output_file: Destination file to generate
     :type output_file: str
+    :param output_format: Destination file output format
+    :type output_format: str
     :param options: Filtering options for network, station and channel codes, defaults to None
     :param options: Python dict of key-values pairs matching command line options, optional
     """
+    assert output_format in OUTPUT_FORMATS
     iris_url = formChannelRequestUrl() if options is None else formChannelRequestUrl(**options)
     # Download latest IRIS station database as FDSN station xml.
     try:
@@ -74,33 +80,65 @@ def updateIrisStationXml(output_file, options=None):
         print("FAILED to retrieve URL content at " + iris_url)
         return
 
-    try:
-        # Since there are not available Python bindings for the conversion, we have to dump FDSN stxml to file
-        # first, then convert to seiscomp3 stxml inventory using system call.
-        ifile = tmp.NamedTemporaryFile("w", delete=False)
-        ifile.write(iris.text)
-        ifile.close()
-        # Convert using helper module
-        print("Converting to SC3 format...")
-        toSc3ml(ifile.name, output_file)
-        print("Successfully updated file " + output_file)
-    except:
-        cleanup(ifile.name)
-        raise
+    # Repair errors with IRIS data
+    print("Correcting known data errors...")
+    iris_fixed = repair_iris_metadata(iris)
+    iris.close()
 
-    cleanup(ifile.name)
+    if output_format == 'SC3':
+        try:
+            # Since there are not available Python bindings for the conversion, we have to dump FDSN stxml to file
+            # first, then convert to seiscomp3 stxml inventory using system call.
+            ifile = tmp.NamedTemporaryFile("w", delete=False)
+            ifile.write(iris_fixed)
+            ifile.close()
+            # Convert using helper module
+            print("Converting to SC3 format...")
+            toSc3ml(ifile.name, output_file)
+            print("Successfully updated file " + output_file)
+        except:
+            cleanup(ifile.name)
+            raise
+
+        cleanup(ifile.name)
+    elif output_format == 'FDSN':
+        with open(output_file, 'w') as f:
+            f.write(iris_fixed)
+    else:
+        assert False, "Unknown output format {}".format(output_format)
 
     # Create human-readable text form of the IRIS station inventory (Pandas stringified table)
     output_txt = os.path.splitext(output_file)[0] + ".txt"
-    regenerateHumanReadable(iris, output_txt)
+    regenerate_human_readable(iris_fixed, output_txt)
 
 
-def regenerateHumanReadable(iris, outfile):
+def repair_iris_metadata(iris):
+    """Perform text subtitutions to fix known errors in station xml returned from IRIS
+
+    :param iris: [description]
+    :type iris: [type]
+    :return: [description]
+    :rtype: [type]
+    """
+
+    def repair_match(match):
+        for pattern, replacement in KNOWN_ILLEGAL_ELEMENTS_PATTERNS.items():
+            if re.match(pattern, match.group()):
+                return replacement
+        return ""
+
+    # This code repairs illegal data matching KNOWN_ILLEGAL_ELEMENTS_PATTERNS from iris.text
+    matcher = re.compile("|".join(list(KNOWN_ILLEGAL_ELEMENTS_PATTERNS.keys())))
+    iris_text_fixed = matcher.sub(repair_match, iris.text)
+    return iris_text_fixed
+
+
+def regenerate_human_readable(iris_data, outfile):
     """
     Generate human readable, tabular version of the IRIS database.
 
-    :param iris: Query response object containing result string returned from IRIS query.
-    :type iris: requests.Response
+    :param iris_data: String containing result string returned from IRIS query (without data errors).
+    :type iris_data: str
     :param outfile: Output text file name
     :type outfile: str
     """
@@ -111,16 +149,13 @@ def regenerateHumanReadable(iris, outfile):
     from obspy import read_inventory
 
     if sys.version_info[0] < 3:
-        import cStringIO as sio  # pylint: disable=import-error
+        from cStringIO import StringIO as sio  # pylint: disable=import-error
     else:
-        import io as sio
+        from io import BytesIO as sio
 
+    iris_str = iris_data.encode('utf-8')
     print("  Ingesting query response into obspy...")
-    # This code removes all instances of the substrings matching KNOWN_ILLEGAL_ELEMENTS_PATTERNS from iris.text,
-    # then encodes it as UTF-8.
-    matcher = re.compile("|".join(KNOWN_ILLEGAL_ELEMENTS_PATTERNS))
-    iris_str = matcher.sub("", iris.text).encode('utf-8')
-    obspy_input = sio.BytesIO(iris_str)
+    obspy_input = sio(iris_str)
     try:
         station_inv = read_inventory(obspy_input)
     except:
@@ -142,17 +177,24 @@ def regenerateHumanReadable(iris, outfile):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
-    parser.add_argument("-n", "--netmask", help="Filter mask to apply to network codes, e.g. U* to get all network codes starting with \"U\"")
-    parser.add_argument("-s", "--statmask", help="Filter mask to apply to station codes. Filter strings should not include quotation marks.")
+    parser.add_argument("-n", "--netmask", help="Filter mask to apply to network codes, "
+                        "e.g. U* to get all network codes starting with \"U\"")
+    parser.add_argument("-s", "--statmask", help="Filter mask to apply to station codes. "
+                        "Filter strings should not include quotation marks.")
     parser.add_argument("-c", "--chanmask", help="Filter mask to apply to channel codes.")
     parser.add_argument("-o", "--output", help="Name of output file.", default=DEFAULT_OUTPUT_FILE)
+    parser.add_argument("-f", "--format", default="SC3", help="Output format, from {}".format(OUTPUT_FORMATS))
     args = vars(parser.parse_args())
-    filter_args = {k: v for k, v in args.items() if v is not None and k != "output"}
+    filter_args = {k: v for k, v in args.items() if v is not None and k not in ["output", "format"]}
     output_filename = args['output']
-    print("Destination file: " + output_filename)
+    output_format = args['format']
+    if output_format not in OUTPUT_FORMATS:
+        print("Allowed output formats: {}".format(OUTPUT_FORMATS))
+        exit(0)
+    print("Destination file: " + output_filename + " (" + output_format + " format)")
     time.sleep(1)
 
     if filter_args:
-        updateIrisStationXml(output_filename, filter_args)
+        update_iris_station_xml(output_filename, output_format, filter_args)
     else:
-        updateIrisStationXml(output_filename)
+        update_iris_station_xml(output_filename, output_format)


### PR DESCRIPTION
Next major iteration of inventory cleanup and curation. The key workflow and process change here is that we generate station xml files that fully include the IRIS inventory merged with the curated inventory from our bespoke STN files. The `engd2stxml.py` script now only does the curation of STN files and saves them to station xml. Then there are separate scripts to merge it with IRIS (`inventory_merge.py`) and split out to separate files per network (`inventory_split.py`) before converting to sc3ml (`fdsnxml_convert.py`).
