### PR TITLE
Minor Bug Fix and Enhancements

### DIFF
--- a/iloc_rstt/iloc_phase_ident.py
+++ b/iloc_rstt/iloc_phase_ident.py
@@ -46,14 +46,15 @@ def split_list(lst, npartitions):
 def runprocess(cmd, get_results=False):
     results = []
     p = subprocess.Popen(cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-    for line in p.stdout:
+    pstdout, pstderr = p.communicate()
+    for line in pstdout.splitlines():
         if (get_results): results.append(line.strip())
         #else: print line
     # end for
 
-    #for line in p.stderr:
+    #for line in pstderr.splitlines():
     #    print line
-    p.wait()
+    #end for
 
     return p.returncode, results
 # end func


### PR DESCRIPTION
* Subprocess calls were stalling due to copious amounts of stdout/err output from
  process launched. This is a known issue and the recommended approach is to
  retrieve all stdout/err output after the process terminates.

* Setting quality metrics columns to -999 for preexisting picks.