### PR TITLE
Rf inversion bounds checking

### DIFF
--- a/seismic/receiver_fn/inversion/rj-rf-Nita/Makefile
+++ b/seismic/receiver_fn/inversion/rj-rf-Nita/Makefile
@@ -4,10 +4,14 @@
 ifeq ($(TARGET_ARCH),AVX2)
   # This build is much faster on Intel CPUs with AVX2 instruction set.
   # To generate this build on NCI, run 'setup_make_avx2.sh' shell script first.
-  FC = mpifort -mcmodel=medium -O2 -march=core-avx2 -axCORE-AVX2 -xCORE-AVX2 -check all
+  FC = mpifort -mcmodel=medium -O2 -march=core-avx2 -axCORE-AVX2 -xCORE-AVX2
+  # Uncomment to add runtime checks option (slows down runtime)
+#  FC += -check all
   TARGET = run_avx2
 else
-  FC = mpifort -mcmodel=medium -O2 -fcheck-array-temporaries -fbounds-check
+  FC = mpifort -mcmodel=medium -O2
+  # Uncomment to add runtime checks option (slows down runtime)
+#  FC += -fcheck-array-temporaries -fbounds-check
   TARGET = run
 endif
 

--- a/seismic/receiver_fn/inversion/rj-rf-Nita/Makefile
+++ b/seismic/receiver_fn/inversion/rj-rf-Nita/Makefile
@@ -4,10 +4,10 @@
 ifeq ($(TARGET_ARCH),AVX2)
   # This build is much faster on Intel CPUs with AVX2 instruction set.
   # To generate this build on NCI, run 'setup_make_avx2.sh' shell script first.
-  FC = mpifort -mcmodel=medium -O2 -march=core-avx2 -axCORE-AVX2 -xCORE-AVX2
+  FC = mpifort -mcmodel=medium -O2 -march=core-avx2 -axCORE-AVX2 -xCORE-AVX2 -check all
   TARGET = run_avx2
 else
-  FC = mpifort -mcmodel=medium -O2
+  FC = mpifort -mcmodel=medium -O2 -fcheck-array-temporaries -fbounds-check
   TARGET = run
 endif
 

--- a/seismic/receiver_fn/inversion/rj-rf-Nita/RJ_MCMC_RF.f90
+++ b/seismic/receiver_fn/inversion/rj-rf-Nita/RJ_MCMC_RF.f90
@@ -184,6 +184,9 @@ character(len=256) :: output_folder
 
 !***********************************************************************
 
+! Initialize variables
+Prnr = 0
+
 !**************************************************************
 
 !                  CHECK AND READ ARGUMENTS
@@ -504,6 +507,9 @@ do while (sample<nsample)
 		endif
 	elseif (u<0.3) then ! Change noise parameter for receiver function
 		noisr=1
+        ! 22 Nov 2019: BUG FOUND HERE ON INTEL COMPILER
+        ! forrtl: severe (194): Run-Time Check Failure. The variable
+        ! 'rj_mcmc_rf_$PRNR' is being used in 'RJ_MCMC_RF.f90(507,3)' without being defined
 		Prnr = Prnr + 1
 		Ar_prop = Ar+gasdev(ra)*pAr
 		!Check if oustide bounds of prior

--- a/seismic/receiver_fn/inversion/rj-rf-Nita/RJ_MCMC_RF.f90
+++ b/seismic/receiver_fn/inversion/rj-rf-Nita/RJ_MCMC_RF.f90
@@ -482,7 +482,7 @@ do while (sample<nsample)
 
 	if (u<0.1) then !change position--------------------------------------------
 		move=1
-		ind=ceiling(ran3(ra)*npt)
+		ind=ceiling(ran3(ra)*npt)  ! FIXME: Potentially invalid index (may be 0, min valid index is 1)
 		if (ount.GT.burn_in) then 
 			if (voro(ind,1)<(d_max/2)) then
 				PrP(1)=PrP(1)+1
@@ -517,7 +517,7 @@ do while (sample<nsample)
 
 	elseif (u<0.4) then ! change value---------------------------------------------------------
 		value=1
-		ind=ceiling(ran3(ra)*npt)
+		ind=ceiling(ran3(ra)*npt)  ! FIXME: Potentially invalid index (may be 0, min valid index is 1)
 		if (ount.GT.burn_in) then 
 			if (voro(ind,1)<(d_max/2)) then
 				PrV(1)=PrV(1)+1
@@ -560,7 +560,7 @@ do while (sample<nsample)
 	else !death!---------------------------------------	
 			death = 1
 			PrD = PrD + 1
-			ind=ceiling(ran3(ra)*npt)
+			ind=ceiling(ran3(ra)*npt)  ! FIXME: Potentially invalid index (may be 0, min valid index is 1)
 			npt_prop=npt-1
 			if (npt_prop<npt_min) then
 				 out=0
@@ -726,13 +726,13 @@ IF (ount.GT.burn_in) THEN
 			d=(i-1)*prof/real(disd-1)
 			if (d<ht)then
 				v=ceiling((beta(l)-beta_min+width)*&
-				disv/(beta_max+2*width-beta_min))
+				disv/(beta_max+2*width-beta_min))  ! FIXME: Potentially invalid index (may be 0, min valid index is 1)
 				post(i,v)=post(i,v)+1
 		
 			else	
 				l=l+1
 				v=ceiling((beta(l)-beta_min+width)*&
-				disv/(beta_max+2*width-beta_min))
+				disv/(beta_max+2*width-beta_min))  ! FIXME: Potentially invalid index (may be 0, min valid index is 1)
 				post(i,v)=post(i,v)+1
 		
 				if (l<npt) then
@@ -743,14 +743,14 @@ IF (ount.GT.burn_in) THEN
 			endif
 		enddo
 		
-		i=ceiling((Ar-Ar_min)*disA/(Ar_max-Ar_min))
+		i=ceiling((Ar-Ar_min)*disA/(Ar_max-Ar_min))  ! FIXME: Potentially invalid index (may be 0, min valid index is 1)
 		ML_Ar(i) = ML_Ar(i)+1
 		
 		!Get distribution on changepoint locations.
 		ht=0
 		do i=1,npt-1
 		ht=ht+h(i)
-		j=ceiling((ht)*disd/(prof))
+		j=ceiling((ht)*disd/(prof))  ! FIXME: Potentially invalid index (may be 0, min valid index is 1)
 		histoch(j)=histoch(j)+1
 		enddo	
 		

--- a/seismic/receiver_fn/inversion/rj-rf-Nita/RJ_MCMC_RF.f90
+++ b/seismic/receiver_fn/inversion/rj-rf-Nita/RJ_MCMC_RF.f90
@@ -508,9 +508,6 @@ do while (sample<nsample)
 		endif
 	elseif (u<0.3) then ! Change noise parameter for receiver function
 		noisr=1
-        ! 22 Nov 2019: BUG FOUND HERE BY INTEL COMPILER
-        ! forrtl: severe (194): Run-Time Check Failure. The variable
-        ! 'rj_mcmc_rf_$PRNR' is being used in 'RJ_MCMC_RF.f90(507,3)' without being defined
 		Prnr = Prnr + 1
 		Ar_prop = Ar+gasdev(ra)*pAr
 		!Check if oustide bounds of prior
@@ -645,9 +642,6 @@ do while (sample<nsample)
  		logrsig=ndatar*log(Ar/Ar_prop)
         	if (log(ran3(ra))<logrsig+log(out)-like_prop+like) then
             		accept=1
-            ! 22 Nov 2019: BUG FOUND HERE BY INTEL COMPILER
-            ! forrtl: severe (194): Run-Time Check Failure. The variable 'rj_mcmc_rf_$ACNR'
-            ! is being used in 'RJ_MCMC_RF.f90(647,4)' without being defined
 			Acnr=Acnr+1
         	endif
 	

--- a/seismic/receiver_fn/inversion/rj-rf-Nita/RJ_MCMC_RF.f90
+++ b/seismic/receiver_fn/inversion/rj-rf-Nita/RJ_MCMC_RF.f90
@@ -186,6 +186,7 @@ character(len=256) :: output_folder
 
 ! Initialize variables
 Prnr = 0
+Acnr = 0
 
 !**************************************************************
 
@@ -507,7 +508,7 @@ do while (sample<nsample)
 		endif
 	elseif (u<0.3) then ! Change noise parameter for receiver function
 		noisr=1
-        ! 22 Nov 2019: BUG FOUND HERE ON INTEL COMPILER
+        ! 22 Nov 2019: BUG FOUND HERE BY INTEL COMPILER
         ! forrtl: severe (194): Run-Time Check Failure. The variable
         ! 'rj_mcmc_rf_$PRNR' is being used in 'RJ_MCMC_RF.f90(507,3)' without being defined
 		Prnr = Prnr + 1
@@ -644,6 +645,9 @@ do while (sample<nsample)
  		logrsig=ndatar*log(Ar/Ar_prop)
         	if (log(ran3(ra))<logrsig+log(out)-like_prop+like) then
             		accept=1
+            ! 22 Nov 2019: BUG FOUND HERE BY INTEL COMPILER
+            ! forrtl: severe (194): Run-Time Check Failure. The variable 'rj_mcmc_rf_$ACNR'
+            ! is being used in 'RJ_MCMC_RF.f90(647,4)' without being defined
 			Acnr=Acnr+1
         	endif
 	

--- a/seismic/receiver_fn/inversion/rj-rf-Nita/run_rf.sh
+++ b/seismic/receiver_fn/inversion/rj-rf-Nita/run_rf.sh
@@ -3,14 +3,14 @@
 #   qsub -M my_email_address -N jobname -v INFILE=input_filename,OUT=output_folder ./run_rf.sh
 #PBS -P vy72
 #PBS -q normalbw
-#PBS -l walltime=24:00:00,mem=16GB,ncpus=28,jobfs=200MB
+#PBS -l walltime=48:00:00,mem=16GB,ncpus=28,jobfs=200MB
 #PBS -l other=hyperthread
 #PBS -l wd
 #PBS -j oe
 #PBS -m bae
 
 module purge
-module load openmpi/1.10.2-mt
+module load openmpi/1.10.2
 # export OMP_NUM_THREADS=4
 echo $INFILE
 echo $OUT

--- a/seismic/receiver_fn/inversion/rj-rf-Nita/run_rf_avx2.sh
+++ b/seismic/receiver_fn/inversion/rj-rf-Nita/run_rf_avx2.sh
@@ -3,14 +3,14 @@
 #   qsub -M my_email_address -N jobname -v INFILE=input_filename,OUT=output_folder ./run_rf.sh
 #PBS -P vy72
 #PBS -q normalbw
-#PBS -l walltime=24:00:00,mem=16GB,ncpus=28,jobfs=200MB
+#PBS -l walltime=48:00:00,mem=16GB,ncpus=28,jobfs=200MB
 #PBS -l other=hyperthread
 #PBS -l wd
 #PBS -j oe
 #PBS -m bae
 
 module purge
-module load openmpi/1.10.2-mt
+module load openmpi/1.10.2
 # export OMP_NUM_THREADS=4
 echo $INFILE
 echo $OUT


### PR DESCRIPTION
Fixing uninitialized variables. Flagging locations of potentially invalid array index values.

Leaving in commented Makefile flags for bounds checking for future re-use, so the next person doesn't have to look up compiler-specific references on how to turn these checks on.