### PR TITLE
Reduced log level output for xcorr unit test

### DIFF
--- a/seismic/xcorqc/xcorqc.py
+++ b/seismic/xcorqc/xcorqc.py
@@ -451,7 +451,8 @@ def IntervalStackXCorr(refds, tempds,
                        clip_to_2std=False, whitening=False, whitening_window_frequency=0,
                        one_bit_normalize=False, envelope_normalize=False,
                        ensemble_stack=False,
-                       outputPath='/tmp', verbose=1, tracking_tag=''):
+                       outputPath='/tmp', verbose=1, tracking_tag='',
+                       log_level=logging.INFO):
     """
     This function rolls through two ASDF data sets, over a given time-range and cross-correlates
     waveforms from all possible station-pairs from the two data sets. To allow efficient, random
@@ -561,7 +562,7 @@ def IntervalStackXCorr(refds, tempds,
     # setup logger
     stationPair = '%s.%s'%(ref_net_sta, temp_net_sta)
     fn = os.path.join(outputPath, '%s.log'%(stationPair if not tracking_tag else '.'.join([stationPair, tracking_tag])))
-    logger = setup_logger('%s.%s'%(ref_net_sta, temp_net_sta), fn)
+    logger = setup_logger('%s.%s'%(ref_net_sta, temp_net_sta), fn, level=log_level)
 
     #######################################
     # Initialize variables for main loop

--- a/tests/seismic/xcorqc/test_interval_stack_xcorr.py
+++ b/tests/seismic/xcorqc/test_interval_stack_xcorr.py
@@ -13,6 +13,7 @@ Revision History:
     LastUpdate:     dd/mm/yyyy  Who     Optional description
 """
 
+import logging
 from seismic.ASDFdatabase.FederatedASDFDataSet import FederatedASDFDataSet
 from seismic.xcorqc.xcorqc import IntervalStackXCorr
 from obspy import read_inventory
@@ -128,7 +129,8 @@ def test_interval_stack_xcorr_(tmpdir, cha, inv1, inv2, interval_seconds, window
                        clip_to_2std=clip_to_2std, whitening=whitening,
                        one_bit_normalize=one_bit_normalize, envelope_normalize=envelope_normalize,
                        ensemble_stack=ensemble_stack,
-                       outputPath=output_folder, verbose=2, tracking_tag=tag)
+                       outputPath=output_folder, verbose=2, tracking_tag=tag,
+                       log_level=logging.ERROR)
 
     # Read result
     fn = os.path.join(output_folder, '%s.%s.%s.nc'%(netsta1, netsta2, tag))


### PR DESCRIPTION
Reduced logging level for xcorr when running unit tests, so that other important test output doesn't get lost amongst INFO level messages.