### PR TITLE
Xcorr jobfs

### DIFF
--- a/seismic/xcorqc/correlator.py
+++ b/seismic/xcorqc/correlator.py
@@ -137,7 +137,7 @@ def process(data_source1, data_source2, output_path,
             ds1_zchan=None, ds1_nchan=None, ds1_echan=None,
             ds2_zchan=None, ds2_nchan=None, ds2_echan=None, corr_chan=None,
             envelope_normalize=False, ensemble_stack=False, restart=False, dry_run=False,
-            no_tracking_tag=False):
+            no_tracking_tag=False, scratch_folder=None):
     """
     :param data_source1: Text file containing paths to ASDF files
     :param data_source2: Text file containing paths to ASDF files
@@ -210,6 +210,7 @@ def process(data_source1, data_source2, output_path,
             f.write('%25s\t\t\t: %s\n' % ('--ensemble-stack', ensemble_stack))
             f.write('%25s\t\t\t: %s\n' % ('--restart', 'TRUE' if restart else 'FALSE'))
             f.write('%25s\t\t\t: %s\n' % ('--no-tracking-tag', 'TRUE' if no_tracking_tag else 'FALSE'))
+            f.write('%25s\t\t\t: %s\n' % ('--scratch-folder', scratch_folder))
 
             f.close()
         # end func
@@ -355,7 +356,7 @@ def process(data_source1, data_source2, output_path,
                            window_seconds, window_overlap, window_buffer_length,
                            fmin, fmax, clip_to_2std, whitening, whitening_window_frequency,
                            one_bit_normalize, envelope_normalize, ensemble_stack,
-                           output_path, 2, time_tag)
+                           output_path, 2, time_tag, scratch_folder)
     # end for
 # end func
 
@@ -472,12 +473,13 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.option('--dry-run', default=False, is_flag=True, help='Dry run for printing out station-pairs and '
                                                              'additional stats.')
 @click.option('--no-tracking-tag', default=False, is_flag=True, help='Do not tag output file names with a time-tag')
+@click.option('--scratch-folder', default=None, help='Scratch folder for large jobs; default is to use the standard temp folder')
 def main(data_source1, data_source2, output_path, interval_seconds, window_seconds, window_overlap,
          window_buffer_length, resample_rate, taper_length, nearest_neighbours, fmin, fmax, station_names1,
          station_names2, pairs_to_compute, start_time, end_time, instrument_response_inventory, instrument_response_output,
          water_level, clip_to_2std, whitening, whitening_window_frequency, one_bit_normalize, read_buffer_size,
          ds1_zchan, ds1_nchan, ds1_echan, ds2_zchan, ds2_nchan, ds2_echan, corr_chan, envelope_normalize,
-         ensemble_stack, restart, dry_run, no_tracking_tag):
+         ensemble_stack, restart, dry_run, no_tracking_tag, scratch_folder):
     """
     :param data_source1: Text file containing paths to ASDF files
     :param data_source2: Text file containing paths to ASDF files
@@ -497,7 +499,7 @@ def main(data_source1, data_source2, output_path, interval_seconds, window_secon
             station_names2, pairs_to_compute, start_time, end_time, instrument_response_inventory, instrument_response_output,
             water_level, clip_to_2std, whitening, whitening_window_frequency, one_bit_normalize, read_buffer_size,
             ds1_zchan, ds1_nchan, ds1_echan, ds2_zchan, ds2_nchan, ds2_echan, corr_chan, envelope_normalize,
-            ensemble_stack, restart, dry_run, no_tracking_tag)
+            ensemble_stack, restart, dry_run, no_tracking_tag, scratch_folder)
 # end func
 
 if __name__ == '__main__':

--- a/seismic/xcorqc/correlator.py
+++ b/seismic/xcorqc/correlator.py
@@ -473,7 +473,8 @@ CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 @click.option('--dry-run', default=False, is_flag=True, help='Dry run for printing out station-pairs and '
                                                              'additional stats.')
 @click.option('--no-tracking-tag', default=False, is_flag=True, help='Do not tag output file names with a time-tag')
-@click.option('--scratch-folder', default=None, help='Scratch folder for large jobs; default is to use the standard temp folder')
+@click.option('--scratch-folder', default=None, help="Scratch folder for large jobs (e.g. $PBS_JOBFS on the NCI); "
+                                                     "default is to use the standard temp folder')
 def main(data_source1, data_source2, output_path, interval_seconds, window_seconds, window_overlap,
          window_buffer_length, resample_rate, taper_length, nearest_neighbours, fmin, fmax, station_names1,
          station_names2, pairs_to_compute, start_time, end_time, instrument_response_inventory, instrument_response_output,

--- a/seismic/xcorqc/utils.py
+++ b/seismic/xcorqc/utils.py
@@ -206,14 +206,14 @@ class SpooledXcorrResults:
     output all cross-correlations, unstacked, the memory requirements have jumped by a factor of
     ~26. We now write the CCs to a spooled storage as they are being computed.
     """
-    def __init__(self, ncols, dtype=np.float32, max_size_mb=2048, prefix=''):
+    def __init__(self, ncols, dtype=np.float32, max_size_mb=2048, prefix='', dir=None):
         self._prefix = prefix
         self._ncols = ncols
         self._nrows = 0
         self._dtype = dtype
         self._max_size_mb = max_size_mb
 
-        self._file = SpooledTemporaryFile(prefix = self._prefix, mode = 'w+b', max_size = max_size_mb * 1024**2)
+        self._file = SpooledTemporaryFile(prefix = self._prefix, mode = 'w+b', max_size = max_size_mb * 1024**2, dir=dir)
     # end func
     
     @property

--- a/seismic/xcorqc/xcorqc.py
+++ b/seismic/xcorqc/xcorqc.py
@@ -463,7 +463,7 @@ def IntervalStackXCorr(refds, tempds,
                        clip_to_2std=False, whitening=False, whitening_window_frequency=0,
                        one_bit_normalize=False, envelope_normalize=False,
                        ensemble_stack=False,
-                       outputPath='/tmp', verbose=1, tracking_tag=''):
+                       outputPath='/tmp', verbose=1, tracking_tag='', scratch_folder=None):
     """
     This function rolls through two ASDF data sets, over a given time-range and cross-correlates
     waveforms from all possible station-pairs from the two data sets. To allow efficient, random
@@ -679,7 +679,13 @@ def IntervalStackXCorr(refds, tempds,
         # end if
 
         if(spooledXcorr is None):
-            spooledXcorr = SpooledXcorrResults(xcl.shape[1], dtype=xcl.dtype, max_size_mb=2048, prefix=stationPair)
+            prefix = None
+            if(scratch_folder):
+                prefix = os.path.join(scratch_folder, stationPair)
+            else:
+                prefix = stationPair
+            # end if
+            spooledXcorr = SpooledXcorrResults(xcl.shape[1], dtype=xcl.dtype, max_size_mb=2048, prefix=prefix)
         # end if
         
         # write xcorr results to spooled buffer

--- a/seismic/xcorqc/xcorqc.py
+++ b/seismic/xcorqc/xcorqc.py
@@ -679,13 +679,7 @@ def IntervalStackXCorr(refds, tempds,
         # end if
 
         if(spooledXcorr is None):
-            prefix = None
-            if(scratch_folder):
-                prefix = os.path.join(scratch_folder, stationPair)
-            else:
-                prefix = stationPair
-            # end if
-            spooledXcorr = SpooledXcorrResults(xcl.shape[1], dtype=xcl.dtype, max_size_mb=2048, prefix=prefix)
+            spooledXcorr = SpooledXcorrResults(xcl.shape[1], dtype=xcl.dtype, max_size_mb=2048, prefix=stationPair, dir=scratch_folder)
         # end if
         
         # write xcorr results to spooled buffer

--- a/seismic/xcorqc/xcorr.pbs
+++ b/seismic/xcorqc/xcorr.pbs
@@ -1,0 +1,25 @@
+#!/bin/bash
+#PBS -P vy72
+#PBS -N xcorr.288
+#PBS -q normal
+#PBS -l walltime=24:00:00,mem=1152GB,ncpus=288,jobfs=160GB
+#PBS -l storage=scratch/rxh562+gdata/ha3
+#PBS -l wd
+#PBS -j oe
+#PBS -M email@ga.gov.au
+#PBS -m bae
+
+module purge
+module load pbs
+module load python3-as-python
+module load openmpi/2.1.6-mt
+module load hdf5/1.10.5p
+
+export PATH=$HOME/.local/bin:$PATH
+export PYTHONPATH=/g/data/ha3/rakib/seismic/pst/hiperseis/:$PYTHONPATH
+export LC_ALL=en_AU.UTF-8
+export LANG=en_AU.UTF-8
+
+mpirun -np 288 python /g/data/ha3/rakib/seismic/pst/hiperseis/seismic/xcorqc/correlator.py /g/data/ha3/Passive/SHARED_DATA/Index/asdf_files.txt /g/data/ha3/Passive/SHARED_DATA/Index/asdf_files.txt /g/data/ha3/rakib/xcorTest/tests/output/ 3960 3600 0.1 --window-buffer-length 0.05 --nearest-neighbours -1 --start-time 1970-01-01T00:00:00 --end-time 2021-01-01T00:00:00 --read-buffer-size 240 --resample-rate 4 --fmin .002 --fmax 2 --station-names1 "*"  --station-names2 "*" --whitening --whitening-window-frequency 0.02 --ds1-zchan '*Z' --ds2-zchan '*Z' --corr-chan z --pairs-to-compute pairs_to_compute.txt --no-tracking-tag --scratch-folder $PBS_JOBFS --restart
+
+


### PR DESCRIPTION
The spooled storage implementation for large x-correlation jobs on the NCI can now utilize the temporary file-system ($JOB_FS) created as a part of an NCI job. Prior to this update, jobs requiring large disk storage for spooled data were failing.