### PR TITLE
Change to network code finding function in seismic/catalogue/merge_catalogues_python_new/

### DIFF
--- a/seismic/catalogue/merge_catalogues_python_new/Convert_Catalogues_To_CSV.py
+++ b/seismic/catalogue/merge_catalogues_python_new/Convert_Catalogues_To_CSV.py
@@ -668,6 +668,5 @@ def process():
 #end func
     
 if __name__ == "__main__":
-    pass
-    #process()
+    process()
 #end if

--- a/seismic/catalogue/merge_catalogues_python_new/Convert_Catalogues_To_CSV.py
+++ b/seismic/catalogue/merge_catalogues_python_new/Convert_Catalogues_To_CSV.py
@@ -425,6 +425,37 @@ def find_station_information(stat, net, lon, lat, ot, station_dict,
         dist = ang_dist(lon, lat, slon, slat)
         return slon, slat, selev, net, dist
     else:
+        key = str('IR.' + stat)
+        if key in IR_station_dict.keys():
+            slon, slat, selev, _, _ = IR_station_dict[key]
+            dist = ang_dist(lon, lat, slon, slat)
+            keys = [key for key in station_dict.keys() \
+                if key.split('.')[1] == stat]
+            if len(keys) == 0:
+                return slon, slat, selev, 'IR', dist
+            else:
+                rows = [station_dict[key] for key in keys]
+                slons = np.array([row[0] for row in rows])
+                slats = np.array([row[1] for row in rows])
+                dists = ang_dist(slon, slat, slons, slats)
+                if np.nanmin(dists) < 0.01:
+                    ind = np.argwhere(dists == np.nanmin(dists))[0][0]
+                    slon, slat, selev, _, _ = rows[ind]
+                    net = keys[ind].split('.')[0]
+                    dist = ang_dist(lon, lat, slon, slat)
+                    return slon, slat, selev, net, dist
+                else:
+                    return slon, slat, selev, 'IR', dist
+                #end if
+            #end if
+        else:
+            slon = slat = selev = None
+            dist = 999.0
+            return slon, slat, selev, net, dist
+        #end if
+    #end if
+    """
+    else:
         keys = [key for key in station_dict.keys() \
                 if key.split('.')[1] == stat]
         if len(keys) > 1: #More than one matching record
@@ -471,6 +502,7 @@ def find_station_information(stat, net, lon, lat, ot, station_dict,
             #end if
         #end if
     #end if
+    """
 #end func
     
 def write_list_to_csv(lst, path, rank, nproc):
@@ -636,5 +668,6 @@ def process():
 #end func
     
 if __name__ == "__main__":
-    process()
+    pass
+    #process()
 #end if

--- a/seismic/catalogue/merge_catalogues_python_new/Filter_Catalogues.py
+++ b/seismic/catalogue/merge_catalogues_python_new/Filter_Catalogues.py
@@ -78,7 +78,7 @@ def azimuth(lon1, lat1, lon2, lat2, units='degrees'):
         a = lon1
         b = np.pi/2.0 - lat1
         x = lon2
-        y = mp.pi/2.0 - lat2
+        y = np.pi/2.0 - lat2
     #end if
     azim = np.arctan(np.sin(x - a)/(np.sin(b)/np.tan(y) - \
                                     np.cos(b)*np.cos(x - a)))

--- a/seismic/ssst_relocation/relocation/Relocation.py
+++ b/seismic/ssst_relocation/relocation/Relocation.py
@@ -244,7 +244,11 @@ def update_hypocentres_from_database(events, picks, hypo_dict, config,
         lat1 = 90.0 - picks_temp['ecolat'][0]
         time1 = picks_temp['origin_time'][0]
         
-        lon2, lat2, depth2, time2 = hypo_dict[event]
+        try:
+            lon2, lat2, depth2, time2 = hypo_dict[event]
+        except:
+            continue
+        #end try
         
         if np.abs(lon1 - lon2) > thr_dist or np.abs(lat1 - lat2) > thr_dist \
             or np.abs(time1 - time2) > thr_time: 
@@ -262,17 +266,11 @@ def update_hypocentres_from_database(events, picks, hypo_dict, config,
     return picks, unstable_events
 #end func
     
-def extract_hypocentres_from_database(events):
+def extract_hypocentres_from_database():
     """
     Retrieves updated hypocentres from SeisComp3 database after relocation has
     been performed.
     
-    
-    Parameters
-    ----------
-    events : list
-        List of event IDs for which to retrieve updated hypocentres.
-        
     
     Returns
     -------
@@ -296,7 +294,7 @@ def extract_hypocentres_from_database(events):
     rows = c.fetchall()
     hypo_dict = {row[0]: (float(row[1]), float(row[2]), float(row[3])*1e3,
                           UTCDateTime(row[4]).timestamp + int(row[5])/1e6) \
-                          for row in rows if row[0] in events}
+                          for row in rows}
     c.close()
     db.close()
     

--- a/seismic/ssst_relocation/relocation/main.py
+++ b/seismic/ssst_relocation/relocation/main.py
@@ -470,10 +470,10 @@ def process():
                                         rank)
             comm.barrier()
             
+            hypo_dict = None
             if rank == 0:
                 from Relocation import extract_hypocentres_from_database
-                events = list(np.unique(picks['event_id']))
-                hypo_dict = extract_hypocentres_from_database(events)
+                hypo_dict = extract_hypocentres_from_database()
             #end if
             
             hypo_dict = comm.bcast(hypo_dict, root=0)
@@ -481,7 +481,7 @@ def process():
                                                '%s.npy'%str(rank).zfill(3)))
             
             picks_split, unstable_events = \
-                update_hypocentres_from_database(events, picks_split, 
+                update_hypocentres_from_database(events_split, picks_split, 
                                                  hypo_dict, config, 
                                                  unstable_events=\
                                                  unstable_events)


### PR DESCRIPTION
I made the changes @rh-downunder suggested to the network code finding function for the catalogue compilation workflow. Also I have made a minor correction to the function which updates the hypocentres of events in the seismic/ssst_relocation/relocation/main.py algorithm to improve computation time.

I am unsure why, but after a few iterations of the relocation algorithm during testing, the function extract_hypocentres_from_database in seismic/ssst_relocation/relocation/Relocation.py fails to find some hypocentres. I suspect this may be because iLoc has failed to find a convergent hypocentre for some of the events, potentially erasing the preferred origin ID from the database. I have changed the code to include a 'try' command in update_hypocentres_from_database to temporarily fix this issue.