### PR TITLE
implement rf length fix

### DIFF
--- a/seismic/receiver_fn/generate_rf_helper.py
+++ b/seismic/receiver_fn/generate_rf_helper.py
@@ -191,5 +191,19 @@ def transform_stream_to_rf(ev_id, stream3c, config_filtering,
         tr.stats.update(metadata)
     # end for
 
+    # If traces are just one sample longer or shorter than the expected length
+    # pad with a zero at the end or remove last sample
+    # If lengths are wildly differnt than expected, trace will be dropped in rf_quality_filter.py
+    expected_length = (trim_end_time_sec - trim_start_time_sec) * resample_rate_hz
+    for tr in stream3c:
+        if tr.data.size == expected_length - 1:
+            tr.data = np.concatenate((tr.data, np.zeros(1)))
+        elif tr.data.size == expected_length + 1:
+            tr.data = tr.data[:-1]
+        elif tr.data.size == expected_length:
+            continue
+        else:
+            logger.warning("Unexpected length of trace {}".format(ev_id))
+
     return stream3c
 # end func


### PR DESCRIPTION
In [optional Stage 3](https://github.com/GeoscienceAustralia/hiperseis/blob/develop/seismic/receiver_fn/README.md#3-rf-quality-filtering) of RF calculation there is a check on the length of RF traces, and assumes the [expected length is the most common length](https://github.com/auggiemarignier/hiperseis/blob/df96fa388ca1292fd9db8ad7a868ddd33e156669/seismic/receiver_fn/rf_quality_filter.py#L251-L261) in the stream.  However after filtering and resampling, sometimes you end up with traces that are one sample too short or long compared to what would be expected from the sampling rate and time window.  These traces would then get dropped in the quality filtering, even if they are actually fine.

This fix simply pads a short RF with a single 0, or removes the last sample of a long trace.