### PR TITLE
handle index error that occurs when data has holes

### DIFF
--- a/seismic/receiver_fn/rf_quality_filter.py
+++ b/seismic/receiver_fn/rf_quality_filter.py
@@ -471,7 +471,7 @@ def main(input_file, output_file, temp_dir=None, parallel=True):
         for station_id, station_stream3c in IterRfH5StationEvents(input_file):
             try:
                 rf_quality_metrics_queue(write_queue, station_id, station_stream3c, similarity_eps)
-            except (ValueError, AssertionError) as e:
+            except (ValueError, AssertionError, IndexError) as e:
                 traceback.print_exc()
                 logger.error("Unhandled exception occurred in rf_quality_metrics_queue for station {}. "
                              "Data will be omitted for this station!\nError:\n{}".format(station_id, str(e)))


### PR DESCRIPTION
I've encountered an edge case in [step 3](https://github.com/GeoscienceAustralia/hiperseis/tree/develop/seismic/receiver_fn#3-rf-quality-filtering) where if there are holes in a trace then a noise or signal window cannot be picked (here)[https://github.com/GeoscienceAustralia/hiperseis/blob/5e18e52b040e4f3e8a19db05e9392bd7961055a8/seismic/receiver_fn/rf_quality_filter.py#L310-L313C1].  In my case, `p_stream` only contained one trace, for which an `event_signal` was found but `noise_signal` was an empty stream.  This leads to an `IndexError` in the following loop.

I've handled the `IndexError` in the calling function [here](https://github.com/GeoscienceAustralia/hiperseis/compare/develop...auggiemarignier:hiperseis:fix_indexerror#diff-df34fefe25254b9cce679060d08a7f705ab0a289e0bf9e115528bda471430e7a).  Note this has only been handled for the serial processing, not parallel where there is no error handling of any kind.